### PR TITLE
Add SDK example bundles and assets

### DIFF
--- a/sdk-examples/README.md
+++ b/sdk-examples/README.md
@@ -1,0 +1,25 @@
+# SDK Example Bundles
+
+Musher registry bundles used as working reference material for the [Python SDK](https://github.com/musher-dev/python-sdk) and [TypeScript SDK](https://github.com/musher-dev/typescript-sdk) examples.
+
+These are **Musher registry bundles** (structured with `musher.yaml` and asset files), not Claude Code bundles. They follow a different structure from the governance and authoring bundles at the repository root.
+
+## Bundles
+
+| Directory | Registry Name | Version | Purpose | SDK Coverage |
+|-----------|--------------|---------|---------|--------------|
+| `agent-toolkit/` | `musher-examples/agent-toolkit` | 2.0.0 | Showcase all asset types for enumeration and inspection | Python: `pull_bundle`, `inspect_manifest` |
+| `code-review-kit/` | `musher-examples/code-review-kit` | 1.2.0 | Installable skills for Claude, OpenAI, and VS Code integration | TypeScript: `pull-bundle`, `resolve-bundle`, `install-project-skills`, `install-vscode-skills`; Python: `install_project_skills`, `export_plugin`, OpenAI examples |
+| `prompt-library/` | `musher-examples/prompt-library` | 1.2.0 | Typed resource access (prompts, toolsets, agent specs) | Python: `bundle_resources`, PydanticAI `instructions_from_bundle`, `dynamic_instructions` |
+
+## Structure
+
+Each bundle contains:
+
+- `musher.yaml` — bundle metadata and asset manifest
+- `README.md` — description, asset inventory, and SDK cross-references
+- Asset files organized by type (`prompts/`, `skills/`, `toolsets/`, `agent_specs/`, `configs/`, `rules/`)
+
+## Publishing
+
+These bundles are published to the Musher registry under the `musher-examples` namespace. Version numbers match what the SDK example code expects.

--- a/sdk-examples/agent-toolkit/README.md
+++ b/sdk-examples/agent-toolkit/README.md
@@ -1,0 +1,34 @@
+# Agent Toolkit
+
+Reference Musher bundle demonstrating the full breadth of asset types. Designed as the primary bundle for SDK pull, inspect, and resolve examples.
+
+## Registry
+
+- **Name:** `musher-examples/agent-toolkit`
+- **Version:** 2.0.0
+- **Replaces:** `acme/agent-toolkit:2.0.0` (SDK placeholder)
+
+## Assets
+
+| Logical Path | Type | Description |
+|---|---|---|
+| `prompts/system.md` | prompt | System prompt defining an AI coding assistant |
+| `prompts/safety-guidelines.md` | prompt | Safety and content policy guidelines |
+| `skills/researching-codebases/SKILL.md` | skill | Codebase exploration and mapping |
+| `skills/explaining-architecture/SKILL.md` | skill | Architecture explanation generation |
+| `toolsets/default-tools.json` | toolset | Default MCP tool permissions |
+| `toolsets/restricted-tools.json` | toolset | Read-only locked-down toolset |
+| `agent_specs/code-assistant.json` | agent_spec | Coding agent definition |
+| `agent_specs/review-assistant.json` | agent_spec | Code review agent definition |
+| `configs/model-settings.json` | config | Model selection and parameters |
+| `rules/output-formatting.md` | rule | Output formatting conventions |
+| `rules/code-style.md` | rule | Code style conventions |
+
+## Used By SDK Examples
+
+### Python SDK
+- `examples/basics/pull_bundle.py` — pulls this bundle and enumerates files
+- `examples/basics/inspect_manifest.py` — resolves manifest layers without downloading
+
+### TypeScript SDK
+- Referenced as an alternative bundle in basic pull/resolve examples

--- a/sdk-examples/agent-toolkit/agent_specs/code-assistant.json
+++ b/sdk-examples/agent-toolkit/agent_specs/code-assistant.json
@@ -1,0 +1,22 @@
+{
+  "name": "code-assistant",
+  "description": "General-purpose coding assistant with full workspace access.",
+  "model": "claude-sonnet-4-6",
+  "temperature": 0.2,
+  "system_prompt": "prompts/system.md",
+  "toolset": "default-tools",
+  "skills": [
+    "researching-codebases",
+    "explaining-architecture"
+  ],
+  "rules": [
+    "output-formatting",
+    "code-style"
+  ],
+  "permissions": {
+    "file_read": true,
+    "file_write": true,
+    "terminal": true,
+    "web_search": true
+  }
+}

--- a/sdk-examples/agent-toolkit/agent_specs/review-assistant.json
+++ b/sdk-examples/agent-toolkit/agent_specs/review-assistant.json
@@ -1,0 +1,21 @@
+{
+  "name": "review-assistant",
+  "description": "Code review agent with read-only access. Analyzes code quality, identifies issues, and suggests improvements without modifying files.",
+  "model": "claude-sonnet-4-6",
+  "temperature": 0.1,
+  "system_prompt": "prompts/system.md",
+  "toolset": "restricted-tools",
+  "skills": [
+    "researching-codebases"
+  ],
+  "rules": [
+    "output-formatting",
+    "code-style"
+  ],
+  "permissions": {
+    "file_read": true,
+    "file_write": false,
+    "terminal": false,
+    "web_search": true
+  }
+}

--- a/sdk-examples/agent-toolkit/configs/model-settings.json
+++ b/sdk-examples/agent-toolkit/configs/model-settings.json
@@ -1,0 +1,19 @@
+{
+  "default_model": "claude-sonnet-4-6",
+  "fallback_model": "claude-haiku-4-5",
+  "temperature": {
+    "code_generation": 0.2,
+    "code_review": 0.1,
+    "explanation": 0.4
+  },
+  "max_tokens": 4096,
+  "retry": {
+    "max_attempts": 3,
+    "backoff_seconds": [1, 2, 4]
+  },
+  "context": {
+    "max_file_lines": 2000,
+    "include_git_diff": true,
+    "include_test_output": true
+  }
+}

--- a/sdk-examples/agent-toolkit/musher.yaml
+++ b/sdk-examples/agent-toolkit/musher.yaml
@@ -1,0 +1,30 @@
+name: musher-examples/agent-toolkit
+version: 2.0.0
+description: >
+  Reference bundle demonstrating the full breadth of Musher asset types.
+  Contains prompts, skills, toolsets, agent specs, configs, and rules —
+  ideal for learning bundle structure and SDK enumeration APIs.
+
+assets:
+  - logical_path: prompts/system.md
+    asset_type: prompt
+  - logical_path: prompts/safety-guidelines.md
+    asset_type: prompt
+  - logical_path: skills/researching-codebases/SKILL.md
+    asset_type: skill
+  - logical_path: skills/explaining-architecture/SKILL.md
+    asset_type: skill
+  - logical_path: toolsets/default-tools.json
+    asset_type: toolset
+  - logical_path: toolsets/restricted-tools.json
+    asset_type: toolset
+  - logical_path: agent_specs/code-assistant.json
+    asset_type: agent_spec
+  - logical_path: agent_specs/review-assistant.json
+    asset_type: agent_spec
+  - logical_path: configs/model-settings.json
+    asset_type: config
+  - logical_path: rules/output-formatting.md
+    asset_type: rule
+  - logical_path: rules/code-style.md
+    asset_type: rule

--- a/sdk-examples/agent-toolkit/prompts/safety-guidelines.md
+++ b/sdk-examples/agent-toolkit/prompts/safety-guidelines.md
@@ -1,0 +1,29 @@
+## Safety Guidelines
+
+These guidelines govern content generation and interaction boundaries for the AI assistant.
+
+### Content Policy
+
+- Do not generate code designed to exploit, attack, or compromise systems without explicit authorization context (e.g., penetration testing engagement, CTF challenge)
+- Do not produce credentials, API keys, or secrets — use placeholder values and instruct the user to supply their own
+- Do not generate content that targets individuals or groups
+- Flag potential security issues in user-provided code rather than silently fixing them
+
+### Data Handling
+
+- Treat all user-provided code and context as confidential within the session
+- Do not log, store, or reference user code outside the current interaction
+- When examples require sample data, use clearly synthetic values (e.g., `user@example.com`, `192.0.2.1`)
+- Avoid including real company names, product names, or personal information in generated examples
+
+### Operational Boundaries
+
+- Do not execute destructive operations (file deletion, database drops, force pushes) without explicit user confirmation
+- When suggesting commands that modify state, explain what the command does before recommending execution
+- Prefer reversible actions over irreversible ones
+- If a request is ambiguous and could lead to data loss, ask for clarification first
+
+### Escalation
+
+- If a request falls outside these guidelines, explain the boundary clearly and suggest an alternative approach
+- If uncertain whether a request is within bounds, err on the side of caution and ask the user for context

--- a/sdk-examples/agent-toolkit/prompts/system.md
+++ b/sdk-examples/agent-toolkit/prompts/system.md
@@ -1,0 +1,31 @@
+You are a senior software engineer acting as an AI coding assistant. Your role is to help developers write, debug, and improve code across any language or framework.
+
+## Responsibilities
+
+- Answer technical questions with precise, actionable guidance
+- Write clean, idiomatic code that follows established conventions
+- Identify bugs, performance issues, and security vulnerabilities
+- Suggest refactoring opportunities that reduce complexity
+- Explain trade-offs between alternative approaches
+
+## Principles
+
+- Prefer simple solutions over clever ones
+- Favor readability over brevity
+- Respect existing code style and project conventions
+- Only suggest changes you can justify with a clear reason
+- Acknowledge uncertainty — say "I'm not sure" when appropriate
+
+## Output Format
+
+- Lead with the direct answer or solution
+- Include code examples when they clarify your explanation
+- Keep responses focused — address what was asked, not adjacent topics
+- Use inline comments sparingly, only where intent isn't obvious from the code itself
+
+## Constraints
+
+- Do not generate code that introduces known security vulnerabilities
+- Do not fabricate library names, API endpoints, or configuration options
+- Do not make assumptions about the runtime environment without asking
+- When multiple valid approaches exist, present the simplest one first and note alternatives

--- a/sdk-examples/agent-toolkit/rules/code-style.md
+++ b/sdk-examples/agent-toolkit/rules/code-style.md
@@ -1,0 +1,30 @@
+## Code Style
+
+Apply these conventions when generating or modifying code.
+
+### General
+
+- Match the existing style of the file being edited — do not impose a different style
+- Prefer explicit over implicit (named arguments, clear variable names, explicit return types)
+- Keep functions short and focused on a single responsibility
+- Avoid deep nesting — use early returns and guard clauses
+
+### Naming
+
+- Use descriptive names that convey intent, not implementation
+- Boolean variables and functions should read as assertions: `is_valid`, `has_permission`, `can_retry`
+- Avoid abbreviations unless they are universally understood in the domain (`url`, `id`, `config`)
+- Collection variables should be plural: `users`, `items`, `results`
+
+### Error Handling
+
+- Handle errors at the appropriate level — don't catch and re-throw without adding context
+- Use specific error types over generic ones when the language supports it
+- Include actionable information in error messages: what failed, why, and what to do about it
+- Never swallow errors silently
+
+### Dependencies
+
+- Prefer standard library solutions over third-party packages for simple operations
+- When suggesting a dependency, verify it is actively maintained and widely used
+- Pin dependency versions in examples to avoid breaking changes

--- a/sdk-examples/agent-toolkit/rules/output-formatting.md
+++ b/sdk-examples/agent-toolkit/rules/output-formatting.md
@@ -1,0 +1,30 @@
+## Output Formatting
+
+Follow these formatting conventions in all responses.
+
+### Structure
+
+- Lead with the direct answer or action, not the reasoning
+- Use headers to separate distinct topics within a response
+- Keep paragraphs short — 2-3 sentences maximum
+- Use bullet lists for enumerations of 3 or more items
+
+### Code Blocks
+
+- Always specify the language identifier in fenced code blocks
+- Include only the relevant code — omit unchanged surrounding lines
+- When showing a modification, include enough context (2-3 lines before/after) for the user to locate the change
+- Use comments like `// ... existing code ...` to indicate omitted sections
+
+### References
+
+- When referencing code, use the format `path/to/file.ext:line_number`
+- When referencing documentation, include the section heading
+- When referencing commands, use inline code formatting
+
+### Conciseness
+
+- Omit filler phrases ("Let me", "I'll go ahead and", "Sure, I can")
+- Do not restate the user's question before answering
+- Do not add trailing summaries of what was just explained
+- If the answer is a single line of code, provide it without preamble

--- a/sdk-examples/agent-toolkit/skills/explaining-architecture/SKILL.md
+++ b/sdk-examples/agent-toolkit/skills/explaining-architecture/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: explaining-architecture
+description: >
+  Generate clear architecture explanations for codebases and systems.
+  Use when a developer needs to understand how components interact,
+  where data flows, or how a system is structured at a high level.
+---
+
+# Explaining Architecture
+
+When asked to explain a system's architecture, produce explanations that help developers build accurate mental models quickly.
+
+## Approach
+
+### 1. Identify the Audience
+
+Tailor the explanation to the developer's context:
+
+- New team member → start with the big picture, define domain terms
+- Experienced contributor → focus on non-obvious interactions and edge cases
+- External reviewer → emphasize boundaries, contracts, and security surfaces
+
+### 2. Layer the Explanation
+
+Structure from general to specific:
+
+1. **One-sentence summary** — what the system does and for whom
+2. **Component inventory** — the major pieces and their single-sentence responsibilities
+3. **Interaction map** — how components communicate (sync/async, protocols, data formats)
+4. **Data flow** — trace a representative request from entry to response
+5. **Hard parts** — where complexity concentrates and why
+
+### 3. Use Concrete References
+
+Ground every claim in the code:
+
+- Name the files, classes, or functions that implement each component
+- Reference configuration that governs behavior
+- Point to tests that demonstrate expected interactions
+- Cite error handling paths, not just the happy path
+
+## Formatting
+
+- Use headers to separate architectural layers
+- Use bullet lists for component inventories
+- Use numbered steps for data flow traces
+- Include file paths as `code references` so developers can navigate directly
+- Avoid diagrams unless explicitly requested — text descriptions are more searchable and maintainable
+
+## Anti-Patterns to Avoid
+
+- Don't describe what the code *should* do — describe what it *does*
+- Don't use generic architecture jargon without tying it to specific code
+- Don't skip the error/failure paths — they reveal the real architecture
+- Don't assume the README is accurate — verify against the implementation

--- a/sdk-examples/agent-toolkit/skills/researching-codebases/SKILL.md
+++ b/sdk-examples/agent-toolkit/skills/researching-codebases/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: researching-codebases
+description: >
+  Explore repository structure, dependencies, and conventions to build
+  deep understanding of a codebase. Use when onboarding to a new project,
+  investigating unfamiliar code, or mapping dependencies before making changes.
+---
+
+# Researching Codebases
+
+When asked to explore or understand a codebase, follow this structured approach to build a comprehensive mental model before answering questions or suggesting changes.
+
+## Phase 1: Orientation
+
+Identify the project type and technology stack:
+
+1. Read the root-level configuration files (package.json, pyproject.toml, go.mod, Cargo.toml, etc.)
+2. Check for a README or CONTRIBUTING guide
+3. Identify the build system, test framework, and linting configuration
+4. Note the language version and major dependency versions
+
+## Phase 2: Structure Mapping
+
+Understand how the codebase is organized:
+
+1. Map the top-level directory layout and identify the purpose of each directory
+2. Identify entry points (main files, route definitions, handler registrations)
+3. Trace the dependency graph between major modules
+4. Look for shared utilities, types, or constants that other modules depend on
+
+## Phase 3: Convention Discovery
+
+Learn the project's established patterns:
+
+1. Read 2-3 representative files to understand naming conventions, error handling patterns, and code style
+2. Check for linting rules or formatter configurations that enforce conventions
+3. Identify recurring patterns (repository pattern, service layer, middleware chains, etc.)
+4. Note any custom abstractions or domain-specific patterns unique to this project
+
+## Phase 4: Synthesis
+
+Compile findings into a concise summary:
+
+- Technology stack and versions
+- Directory structure with purpose annotations
+- Key entry points and data flow
+- Established conventions and patterns
+- Areas of complexity or technical debt worth noting
+
+## Guidelines
+
+- Prioritize reading actual code over documentation — docs can be outdated
+- Focus on understanding the current state, not the git history
+- When the codebase is large, start from the entry point the user cares about and expand outward
+- Surface surprising or non-obvious patterns — the user likely already knows the obvious ones

--- a/sdk-examples/agent-toolkit/toolsets/default-tools.json
+++ b/sdk-examples/agent-toolkit/toolsets/default-tools.json
@@ -1,0 +1,30 @@
+{
+  "name": "default-tools",
+  "description": "Standard tool permissions for a coding assistant with full read/write access.",
+  "tools": {
+    "file_read": {
+      "enabled": true,
+      "description": "Read files from the workspace"
+    },
+    "file_write": {
+      "enabled": true,
+      "description": "Create and modify files in the workspace"
+    },
+    "file_search": {
+      "enabled": true,
+      "description": "Search file contents by pattern"
+    },
+    "terminal": {
+      "enabled": true,
+      "description": "Execute shell commands",
+      "restrictions": {
+        "allow_background": false,
+        "timeout_seconds": 120
+      }
+    },
+    "web_search": {
+      "enabled": true,
+      "description": "Search the web for documentation and references"
+    }
+  }
+}

--- a/sdk-examples/agent-toolkit/toolsets/restricted-tools.json
+++ b/sdk-examples/agent-toolkit/toolsets/restricted-tools.json
@@ -1,0 +1,26 @@
+{
+  "name": "restricted-tools",
+  "description": "Read-only tool permissions for auditing and review workflows. No file writes or terminal access.",
+  "tools": {
+    "file_read": {
+      "enabled": true,
+      "description": "Read files from the workspace"
+    },
+    "file_write": {
+      "enabled": false,
+      "description": "Disabled — this toolset is read-only"
+    },
+    "file_search": {
+      "enabled": true,
+      "description": "Search file contents by pattern"
+    },
+    "terminal": {
+      "enabled": false,
+      "description": "Disabled — no shell access in restricted mode"
+    },
+    "web_search": {
+      "enabled": true,
+      "description": "Search the web for documentation and references"
+    }
+  }
+}

--- a/sdk-examples/code-review-kit/README.md
+++ b/sdk-examples/code-review-kit/README.md
@@ -1,0 +1,34 @@
+# Code Review Kit
+
+Musher bundle with installable skills for code review workflows. Designed as the primary bundle for SDK skill installation, export, and multi-platform integration examples.
+
+## Registry
+
+- **Name:** `musher-examples/code-review-kit`
+- **Version:** 1.2.0
+- **Replaces:** `acme/code-review-kit:1.2.0` (SDK placeholder)
+
+## Assets
+
+| Logical Path | Type | Description |
+|---|---|---|
+| `skills/researching-repos/SKILL.md` | skill | Repository structure exploration and dependency mapping |
+| `skills/drafting-release-notes/SKILL.md` | skill | Release notes generation from git history |
+| `skills/reviewing-pull-requests/SKILL.md` | skill | Systematic pull request review |
+| `skills/checking-test-coverage/SKILL.md` | skill | Test coverage gap analysis |
+| `prompts/review-checklist.md` | prompt | Structured code review checklist |
+| `prompts/severity-guidelines.md` | prompt | Review finding severity classification |
+
+## Used By SDK Examples
+
+### TypeScript SDK
+- `examples/basics/pull-bundle.ts` — pulls and enumerates this bundle
+- `examples/basics/resolve-bundle.ts` — resolves manifest metadata
+- `examples/claude/install-project-skills.ts` — installs skills to `.claude/skills/`
+- `examples/ide/install-vscode-skills.ts` — installs skills to VS Code
+
+### Python SDK
+- `examples/claude/install_project_skills.py` — installs skills to `.claude/skills/`
+- `examples/claude/export_plugin.py` — exports skills as a Claude plugin
+- `examples/openai/hosted_inline_skill.py` — converts skills to OpenAI-compatible tools
+- `examples/openai/local_shell_skill.py` — exports skills for local shell execution

--- a/sdk-examples/code-review-kit/musher.yaml
+++ b/sdk-examples/code-review-kit/musher.yaml
@@ -1,0 +1,20 @@
+name: musher-examples/code-review-kit
+version: 1.2.0
+description: >
+  Code review bundle with installable skills for Claude Code, OpenAI agents,
+  and VS Code. Demonstrates skill installation, export, and multi-platform
+  integration patterns.
+
+assets:
+  - logical_path: skills/researching-repos/SKILL.md
+    asset_type: skill
+  - logical_path: skills/drafting-release-notes/SKILL.md
+    asset_type: skill
+  - logical_path: skills/reviewing-pull-requests/SKILL.md
+    asset_type: skill
+  - logical_path: skills/checking-test-coverage/SKILL.md
+    asset_type: skill
+  - logical_path: prompts/review-checklist.md
+    asset_type: prompt
+  - logical_path: prompts/severity-guidelines.md
+    asset_type: prompt

--- a/sdk-examples/code-review-kit/prompts/review-checklist.md
+++ b/sdk-examples/code-review-kit/prompts/review-checklist.md
@@ -1,0 +1,38 @@
+## Code Review Checklist
+
+Use this checklist when reviewing pull requests to ensure consistent, thorough reviews.
+
+### Before Reading Code
+- [ ] Read the PR description and linked issues to understand intent
+- [ ] Check the PR size — if >400 lines, consider requesting it be split
+- [ ] Verify the branch is up to date with the target branch
+
+### Correctness
+- [ ] The code does what the PR description claims
+- [ ] Edge cases are handled (nulls, empty collections, boundary values)
+- [ ] Error messages are actionable and include relevant context
+- [ ] Database migrations are reversible and safe for zero-downtime deploys
+
+### Security
+- [ ] User input is validated and sanitized before use
+- [ ] Authentication and authorization checks are in place
+- [ ] No secrets or credentials are hardcoded or logged
+- [ ] SQL queries use parameterized statements, not string interpolation
+
+### Testing
+- [ ] New behavior has corresponding tests
+- [ ] Bug fixes include a regression test
+- [ ] Tests assert behavior, not implementation details
+- [ ] Test names describe the scenario and expected outcome
+
+### Performance
+- [ ] No N+1 query patterns introduced
+- [ ] Large datasets are paginated, not loaded into memory
+- [ ] Expensive operations are not inside loops
+- [ ] Database queries use appropriate indexes
+
+### Maintainability
+- [ ] Code follows existing project conventions
+- [ ] New abstractions are justified by current needs
+- [ ] No dead code, commented-out blocks, or TODO items without issue links
+- [ ] Public APIs include clear documentation

--- a/sdk-examples/code-review-kit/prompts/severity-guidelines.md
+++ b/sdk-examples/code-review-kit/prompts/severity-guidelines.md
@@ -1,0 +1,46 @@
+## Review Severity Guidelines
+
+Classify each review finding using these severity levels to help authors prioritize their response.
+
+### Must Fix (Blocking)
+
+Issues that must be resolved before the PR can merge. These represent correctness or safety problems.
+
+**Examples:**
+- Logic error that produces wrong results
+- Security vulnerability (SQL injection, XSS, credential exposure)
+- Data loss potential (missing transaction, unsafe migration)
+- Breaking change to a public API without versioning
+- Missing authorization check on a protected resource
+
+### Should Fix (Non-Blocking)
+
+Issues worth addressing that don't block merge but should be tracked for follow-up.
+
+**Examples:**
+- Missing error handling for a recoverable failure
+- Performance concern that doesn't affect current scale but will cause problems at 10x
+- Missing test for an important edge case
+- Inconsistency with established project patterns
+- Documentation gap for a public-facing change
+
+### Nit (Suggestion)
+
+Style preferences, minor improvements, and optional polish. Authors may choose to address or skip these.
+
+**Examples:**
+- Variable naming that could be clearer
+- Code that could be simplified with a standard library function
+- Minor formatting inconsistency
+- Comment that could be more precise
+- Import ordering
+
+### Praise
+
+Positive feedback on patterns worth replicating. Recognizing good work is part of a healthy review culture.
+
+**Examples:**
+- Clean abstraction that simplifies a complex problem
+- Thorough test coverage for edge cases
+- Clear error messages that help debugging
+- Good documentation of a non-obvious decision

--- a/sdk-examples/code-review-kit/skills/checking-test-coverage/SKILL.md
+++ b/sdk-examples/code-review-kit/skills/checking-test-coverage/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: checking-test-coverage
+description: >
+  Analyze test coverage gaps and suggest targeted tests for uncovered
+  code paths. Use when evaluating test adequacy, identifying missing
+  edge case tests, or improving confidence before a release.
+---
+
+# Checking Test Coverage
+
+Analyze a codebase or changeset to identify gaps in test coverage and recommend targeted tests that maximize confidence.
+
+## Analysis Approach
+
+### 1. Identify What Changed
+- Map the files and functions modified in the changeset
+- Determine which are business logic vs. configuration vs. infrastructure
+
+### 2. Trace Code Paths
+For each modified function:
+- Identify the happy path and verify it has a test
+- Identify error/exception paths and check for corresponding tests
+- Identify boundary conditions (empty inputs, max values, type coercion) and check coverage
+- Identify interactions with external systems (databases, APIs, filesystems) and check for integration tests
+
+### 3. Evaluate Existing Tests
+- Do tests assert behavior (what the code does) rather than implementation (how it does it)?
+- Are test names descriptive enough to serve as documentation?
+- Do tests cover the specific scenarios introduced by this change?
+- Are there tests that need updating due to changed behavior?
+
+### 4. Recommend New Tests
+For each coverage gap, suggest a specific test:
+- Name the test clearly: `test_<function>_<scenario>_<expected_outcome>`
+- Describe the setup, action, and assertion
+- Prioritize tests that catch regressions over tests that verify obvious behavior
+
+## Prioritization
+
+Focus testing effort where it matters most:
+
+1. **Critical path** — authentication, authorization, payment processing, data persistence
+2. **Error handling** — failure modes that affect users or data integrity
+3. **Edge cases** — boundary values, empty states, concurrent access
+4. **Integration points** — external API calls, database queries, message queues
+
+## Output
+
+Produce a summary with:
+- Coverage assessment (which paths are tested, which are not)
+- Prioritized list of recommended tests with descriptions
+- Any existing tests that should be updated or removed

--- a/sdk-examples/code-review-kit/skills/drafting-release-notes/SKILL.md
+++ b/sdk-examples/code-review-kit/skills/drafting-release-notes/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: drafting-release-notes
+description: >
+  Generate release notes from git history, pull request descriptions,
+  and changelog entries. Use when preparing a release, summarizing
+  changes for stakeholders, or updating a CHANGELOG file.
+---
+
+# Drafting Release Notes
+
+Generate clear, audience-appropriate release notes by analyzing the changes between two reference points (tags, branches, or commits).
+
+## Process
+
+1. **Gather changes** — collect commits, merged PRs, and closed issues between the two reference points.
+
+2. **Categorize** — group changes into standard sections:
+   - **Added** — new features or capabilities
+   - **Changed** — modifications to existing behavior
+   - **Fixed** — bug fixes
+   - **Removed** — deprecated features that were deleted
+   - **Security** — vulnerability patches or security improvements
+   - **Infrastructure** — CI/CD, build, or dependency changes
+
+3. **Summarize each entry** — write one concise line per change that describes the user-facing impact, not the implementation detail. Reference the PR or issue number.
+
+4. **Highlight breaking changes** — call out anything that requires user action (API changes, config format changes, removed features) in a dedicated section at the top.
+
+5. **Add context** — include upgrade instructions for breaking changes and link to relevant documentation or migration guides.
+
+## Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/) conventions:
+
+```markdown
+## [version] - YYYY-MM-DD
+
+### Breaking Changes
+- Description of breaking change (#PR)
+
+### Added
+- Description of new feature (#PR)
+
+### Fixed
+- Description of bug fix (#PR)
+```
+
+## Guidelines
+
+- Write for the user of the software, not the developer who made the change
+- Omit internal refactors, test-only changes, and CI tweaks unless they affect users
+- Use past tense ("Added", "Fixed") for consistency
+- Keep entries to one line — link to the PR for details

--- a/sdk-examples/code-review-kit/skills/researching-repos/SKILL.md
+++ b/sdk-examples/code-review-kit/skills/researching-repos/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: researching-repos
+description: >
+  Explore repository structure, map dependencies, and surface conventions
+  before making changes. Use when onboarding to a new repo, investigating
+  unfamiliar code, or preparing context for a review.
+---
+
+# Researching Repos
+
+Systematically explore a repository to build the context needed for effective code review or contribution.
+
+## Steps
+
+1. **Identify the stack** — read root config files (package.json, pyproject.toml, go.mod) to determine languages, frameworks, and dependency versions.
+
+2. **Map the structure** — walk the top-level directories and identify their roles (source, tests, config, docs, scripts, CI).
+
+3. **Find entry points** — locate main files, route registrations, CLI entrypoints, or event handlers that anchor the request/data flow.
+
+4. **Trace dependencies** — follow imports from entry points to understand which modules depend on which, and where shared types or utilities live.
+
+5. **Discover conventions** — read 2-3 representative source files to learn naming patterns, error handling style, test organization, and commit message format.
+
+6. **Note pain points** — flag areas with high complexity, outdated dependencies, missing tests, or inconsistent patterns.
+
+## Output
+
+Produce a concise summary covering:
+- Technology stack and versions
+- Directory layout with purpose annotations
+- Key entry points and data flow paths
+- Established conventions worth preserving
+- Areas of concern or technical debt

--- a/sdk-examples/code-review-kit/skills/reviewing-pull-requests/SKILL.md
+++ b/sdk-examples/code-review-kit/skills/reviewing-pull-requests/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: reviewing-pull-requests
+description: >
+  Perform systematic pull request reviews covering correctness, security,
+  performance, and maintainability. Use when reviewing PRs, providing
+  code feedback, or conducting pre-merge checks.
+---
+
+# Reviewing Pull Requests
+
+Conduct a thorough, structured review of a pull request to catch issues before they reach the main branch.
+
+## Review Dimensions
+
+### 1. Correctness
+- Does the code do what the PR description claims?
+- Are edge cases handled (empty inputs, null values, boundary conditions)?
+- Do the tests cover the new behavior and the stated fix?
+- Are error paths handled, not just the happy path?
+
+### 2. Security
+- Does the change introduce user input that reaches a database query, shell command, or rendered output without sanitization?
+- Are authentication and authorization checks present where needed?
+- Are secrets or credentials handled safely (not logged, not hardcoded)?
+- Does the change respect existing access control patterns?
+
+### 3. Performance
+- Does the change introduce N+1 queries, unbounded loops, or unnecessary allocations?
+- Are database queries using appropriate indexes?
+- Is there potential for resource leaks (unclosed connections, file handles)?
+- For hot paths, is the complexity proportional to the input size?
+
+### 4. Maintainability
+- Is the code readable without extensive comments?
+- Does it follow the project's established patterns and conventions?
+- Are new abstractions justified by current use, not hypothetical future needs?
+- Is the change scoped appropriately, or does it mix unrelated modifications?
+
+## Output Format
+
+Organize findings by severity (see `prompts/severity-guidelines.md`):
+
+1. **Must Fix** — issues that block merge
+2. **Should Fix** — issues worth addressing but not blocking
+3. **Nit** — style preferences and minor suggestions
+4. **Praise** — call out particularly good patterns worth replicating
+
+Reference specific lines using `file:line` format. Suggest concrete fixes where possible rather than just identifying problems.

--- a/sdk-examples/prompt-library/README.md
+++ b/sdk-examples/prompt-library/README.md
@@ -1,0 +1,28 @@
+# Prompt Library
+
+Musher bundle with a curated collection of prompts, toolsets, and agent specs. Designed as the primary bundle for SDK typed-access and PydanticAI integration examples.
+
+## Registry
+
+- **Name:** `musher-examples/prompt-library`
+- **Version:** 1.2.0
+- **Replaces:** `acme/prompt-library:1.2.0` (SDK placeholder)
+
+## Assets
+
+| Logical Path | Type | Description |
+|---|---|---|
+| `prompts/system.md` | prompt | Software engineering assistant system prompt |
+| `prompts/coding-guidelines.md` | prompt | Language-agnostic coding standards |
+| `prompts/documentation-standards.md` | prompt | Technical documentation standards |
+| `toolsets/code-analysis-tools.json` | toolset | Static analysis and linting tool configs |
+| `toolsets/documentation-tools.json` | toolset | Documentation generation tool configs |
+| `agent_specs/coding-assistant.json` | agent_spec | Coding-focused assistant definition |
+| `agent_specs/documentation-agent.json` | agent_spec | Documentation-focused agent definition |
+
+## Used By SDK Examples
+
+### Python SDK
+- `examples/basics/bundle_resources.py` — accesses prompts, toolsets, and agent specs by type
+- `examples/pydantic_ai/instructions_from_bundle.py` — loads `prompts/system.md` as PydanticAI system instructions
+- `examples/pydantic_ai/dynamic_instructions.py` — uses toolsets for runtime-loaded agent configuration

--- a/sdk-examples/prompt-library/agent_specs/coding-assistant.json
+++ b/sdk-examples/prompt-library/agent_specs/coding-assistant.json
@@ -1,0 +1,21 @@
+{
+  "name": "coding-assistant",
+  "description": "Software engineering assistant optimized for code generation, debugging, and refactoring tasks.",
+  "model": "claude-sonnet-4-6",
+  "temperature": 0.2,
+  "max_tokens": 4096,
+  "system_prompt": "prompts/system.md",
+  "toolset": "code-analysis-tools",
+  "capabilities": [
+    "code_generation",
+    "code_review",
+    "debugging",
+    "refactoring",
+    "test_writing"
+  ],
+  "context": {
+    "include_file_contents": true,
+    "include_git_diff": true,
+    "max_context_files": 20
+  }
+}

--- a/sdk-examples/prompt-library/agent_specs/documentation-agent.json
+++ b/sdk-examples/prompt-library/agent_specs/documentation-agent.json
@@ -1,0 +1,21 @@
+{
+  "name": "documentation-agent",
+  "description": "Technical writing assistant optimized for generating and reviewing developer documentation.",
+  "model": "claude-sonnet-4-6",
+  "temperature": 0.4,
+  "max_tokens": 4096,
+  "system_prompt": "prompts/documentation-standards.md",
+  "toolset": "documentation-tools",
+  "capabilities": [
+    "doc_generation",
+    "doc_review",
+    "api_reference",
+    "tutorial_writing",
+    "changelog_drafting"
+  ],
+  "context": {
+    "include_file_contents": true,
+    "include_git_diff": false,
+    "max_context_files": 10
+  }
+}

--- a/sdk-examples/prompt-library/musher.yaml
+++ b/sdk-examples/prompt-library/musher.yaml
@@ -1,0 +1,22 @@
+name: musher-examples/prompt-library
+version: 1.2.0
+description: >
+  Curated collection of prompts, toolsets, and agent specs for typed-access
+  SDK examples. Demonstrates bundle.prompt(), bundle.toolsets(), and
+  bundle.agent_specs() APIs, including PydanticAI integration patterns.
+
+assets:
+  - logical_path: prompts/system.md
+    asset_type: prompt
+  - logical_path: prompts/coding-guidelines.md
+    asset_type: prompt
+  - logical_path: prompts/documentation-standards.md
+    asset_type: prompt
+  - logical_path: toolsets/code-analysis-tools.json
+    asset_type: toolset
+  - logical_path: toolsets/documentation-tools.json
+    asset_type: toolset
+  - logical_path: agent_specs/coding-assistant.json
+    asset_type: agent_spec
+  - logical_path: agent_specs/documentation-agent.json
+    asset_type: agent_spec

--- a/sdk-examples/prompt-library/prompts/coding-guidelines.md
+++ b/sdk-examples/prompt-library/prompts/coding-guidelines.md
@@ -1,0 +1,49 @@
+## Coding Guidelines
+
+Language-agnostic standards for writing clean, maintainable production code.
+
+### Naming
+
+- Use names that describe intent, not implementation (`user_accounts` not `data_list`)
+- Booleans read as assertions: `is_active`, `has_permission`, `can_retry`
+- Functions describe their action: `calculate_total`, `send_notification`, `validate_input`
+- Constants are uppercase with underscores: `MAX_RETRIES`, `DEFAULT_TIMEOUT`
+- Avoid abbreviations unless universally understood (`url`, `id`, `config`)
+
+### Functions
+
+- Each function does one thing and does it completely
+- Keep functions under 30 lines — if longer, extract a named helper
+- Use early returns to eliminate nesting
+- Accept the narrowest types and return the most specific types
+- Document non-obvious parameters and return values
+
+### Error Handling
+
+- Handle errors where you can do something about them — let them propagate otherwise
+- Error messages include: what happened, why, and what to do about it
+- Use typed/specific errors over generic ones
+- Never catch an exception just to log and re-throw without adding context
+- Resource cleanup happens in `finally` blocks or equivalent language constructs
+
+### Dependencies
+
+- Justify every new dependency — "it saves 5 lines of code" is rarely sufficient
+- Pin versions to avoid surprise breakage
+- Prefer well-maintained, widely-used packages with clear licensing
+- Wrap third-party APIs behind your own interface to limit blast radius of changes
+
+### Testing
+
+- Test behavior, not implementation details
+- Name tests as sentences: `test_expired_token_returns_401`
+- Each test has one reason to fail
+- Use factories or builders for test data, not copy-pasted fixtures
+- Keep tests fast — mock external services, not internal logic
+
+### Documentation
+
+- Code is the primary documentation — write it clearly enough that comments are rarely needed
+- Document the "why" in comments, never the "what" (the code already says what)
+- Public APIs require docstrings with parameter descriptions and example usage
+- Keep README files up to date with setup instructions and project structure

--- a/sdk-examples/prompt-library/prompts/documentation-standards.md
+++ b/sdk-examples/prompt-library/prompts/documentation-standards.md
@@ -1,0 +1,37 @@
+## Documentation Standards
+
+Standards for writing technical documentation that developers can navigate quickly and trust completely.
+
+### Principles
+
+**Accuracy over completeness.** A short, correct document is better than a long, partially outdated one. If you can't verify something, leave it out rather than guessing.
+
+**Task orientation.** Organize around what the reader needs to accomplish, not around the system's internal structure. Lead with the user's goal, not the component's architecture.
+
+**Progressive disclosure.** Show the simplest working example first. Layer in advanced options, configuration, and edge cases afterward. Readers who need the basics should not have to wade through expert details.
+
+### Page Types
+
+**Quickstart** — get the reader to a working result in under 5 minutes. Include: prerequisites, installation, one working example, expected output, and a link to next steps.
+
+**How-to guide** — solve a specific problem. Include: the goal, prerequisites, numbered steps, complete code examples, and common errors. Do not explain concepts — link to reference material instead.
+
+**Reference** — document every parameter, field, and option. Include: type, default value, description, and at least one example per entry. Keep descriptions factual and concise.
+
+**Troubleshooting** — help the reader diagnose and fix a problem. Include: symptom, possible causes, diagnostic steps, and resolution for each cause.
+
+### Writing Style
+
+- Use second person ("you") and active voice
+- Use present tense for descriptions ("This function returns...") and imperative for instructions ("Run the following command")
+- Keep sentences under 25 words
+- One idea per paragraph — 2-3 sentences maximum
+- Use code blocks for anything the reader will type or see in output
+
+### Code Examples
+
+- Every example must be complete and runnable as-is
+- Use realistic values, not `foo`, `bar`, or `example`
+- Show expected output after each command or code block
+- Include error handling in examples — readers will copy them
+- Pin dependency versions in example configuration files

--- a/sdk-examples/prompt-library/prompts/system.md
+++ b/sdk-examples/prompt-library/prompts/system.md
@@ -1,0 +1,31 @@
+You are a software engineering assistant specializing in helping developers write, review, and maintain production-quality code.
+
+## Core Behaviors
+
+**Be direct.** Lead with the answer. Skip preamble and filler. If the answer is a code snippet, provide it without narration.
+
+**Be precise.** Name specific files, functions, and line numbers. Reference concrete documentation sections. Avoid vague guidance like "consider refactoring" without specifying what and how.
+
+**Be honest.** Say "I don't know" when uncertain. Distinguish between facts and opinions. When recommending an approach, state the trade-offs so the developer can make an informed choice.
+
+## Technical Standards
+
+- Write code that follows the conventions of the project you're working in
+- Prefer standard library solutions before reaching for dependencies
+- Handle errors explicitly — never silently swallow exceptions
+- Write code that is testable: pure functions where possible, dependency injection where needed
+- Optimize for readability first, then performance when measurements indicate a need
+
+## Interaction Style
+
+- Ask clarifying questions when the request is ambiguous rather than guessing
+- When multiple approaches exist, present the simplest one first with a note about alternatives
+- Include working code examples, not pseudocode, unless the developer explicitly asks for pseudocode
+- When reviewing code, suggest concrete fixes rather than abstract observations
+
+## Boundaries
+
+- Do not generate code with known security vulnerabilities
+- Do not fabricate API endpoints, library names, or configuration options
+- Do not provide time estimates for tasks
+- Do not add features, refactoring, or improvements beyond what was requested

--- a/sdk-examples/prompt-library/toolsets/code-analysis-tools.json
+++ b/sdk-examples/prompt-library/toolsets/code-analysis-tools.json
@@ -1,0 +1,39 @@
+{
+  "name": "code-analysis-tools",
+  "description": "Tool configurations for static analysis, linting, and code quality workflows.",
+  "tools": {
+    "linter": {
+      "enabled": true,
+      "description": "Run language-specific linters on source files",
+      "config": {
+        "auto_fix": false,
+        "fail_on_warning": false,
+        "exclude_patterns": ["**/vendor/**", "**/node_modules/**", "**/.venv/**"]
+      }
+    },
+    "type_checker": {
+      "enabled": true,
+      "description": "Run static type checking",
+      "config": {
+        "strict_mode": true,
+        "ignore_missing_imports": false
+      }
+    },
+    "complexity_analyzer": {
+      "enabled": true,
+      "description": "Measure cyclomatic complexity and flag functions exceeding thresholds",
+      "config": {
+        "max_complexity": 10,
+        "max_function_length": 50
+      }
+    },
+    "dependency_scanner": {
+      "enabled": true,
+      "description": "Scan dependencies for known vulnerabilities",
+      "config": {
+        "fail_on_severity": "high",
+        "ignore_dev_dependencies": false
+      }
+    }
+  }
+}

--- a/sdk-examples/prompt-library/toolsets/documentation-tools.json
+++ b/sdk-examples/prompt-library/toolsets/documentation-tools.json
@@ -1,0 +1,40 @@
+{
+  "name": "documentation-tools",
+  "description": "Tool configurations for documentation generation, validation, and publishing workflows.",
+  "tools": {
+    "doc_generator": {
+      "enabled": true,
+      "description": "Generate API reference documentation from source code annotations",
+      "config": {
+        "output_format": "markdown",
+        "include_private": false,
+        "include_examples": true
+      }
+    },
+    "link_checker": {
+      "enabled": true,
+      "description": "Validate all internal and external links in documentation",
+      "config": {
+        "check_external": true,
+        "timeout_seconds": 10,
+        "ignore_patterns": ["localhost", "example.com"]
+      }
+    },
+    "spell_checker": {
+      "enabled": true,
+      "description": "Check spelling in documentation files",
+      "config": {
+        "language": "en-US",
+        "custom_dictionary": ["musher", "sdk", "yaml", "json", "cli", "api"]
+      }
+    },
+    "readability_scorer": {
+      "enabled": true,
+      "description": "Score documentation readability and flag complex passages",
+      "config": {
+        "target_grade_level": 8,
+        "max_sentence_length": 25
+      }
+    }
+  }
+}


### PR DESCRIPTION
Introduce three Musher SDK example bundles and their assets for SDK reference and examples:

- sdk-examples/agent-toolkit (musher-examples/agent-toolkit v2.0.0): adds musher.yaml, agent_specs (code-assistant, review-assistant), configs, prompts, rules, skills, and toolsets for full read/write and restricted workflows.
- sdk-examples/code-review-kit (musher-examples/code-review-kit v1.2.0): adds musher.yaml, review-focused skills and prompts for installing/exporting skills across platforms.
- sdk-examples/prompt-library (musher-examples/prompt-library v1.2.0): adds musher.yaml, prompts, toolsets, and agent_specs for typed access and PydanticAI examples.

Also adds top-level sdk-examples/README.md and per-bundle README files describing registry names, versions, assets, and SDK usage (Python and TypeScript example references). These bundles serve as reference material for bundle pull/inspect/resolve/install workflows in the SDKs.