### PR TITLE
docs: rewrite bundle READMEs for hub users

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Portable agent bundles for the [Musher](https://musher.dev) platform. Used in pl
 
 ## Bundles
 
-| Bundle | Domain | Purpose |
-|--------|--------|---------|
-| `agent-asset-authoring` | authoring | Templates for creating skills, hooks, rules, and other agent assets |
-| `api-route-governance` | governance | API endpoint design standards — naming, HTTP methods, versioning, errors |
-| `contract-enforcement-governance` | governance | Contract verification across the pipeline — breaking changes, conformance, CI gates |
-| `database-schema-governance` | governance | Database design standards — naming, data types, indexing, structural patterns |
-| `developer-docs-authoring` | authoring | Generate, maintain, and audit developer documentation |
-| `developer-environment-authoring` | authoring | Devcontainer configs, task runners, and workspace setup |
-| `marketing-site-authoring` | authoring | Multi-agent pipeline for marketing site content production |
-| `musher-bundle-scaffolding` | scaffolding | Scaffold new bundle directories with naming validation |
-| `openapi-specification-governance` | governance | OpenAPI specification standards and contract quality |
-| `product-profile-authoring` | authoring | Canonical product metadata, positioning, and roadmaps |
-| `project-shaping-orchestration` | orchestration | Problem framing, solution design, risk assessment, and scoping |
-| `repo-documentation-authoring` | authoring | Repository documentation files for discoverability and community health |
+| Bundle | Purpose |
+|--------|---------|
+| [`agent-asset-authoring`](agent-asset-authoring/) | Generate well-structured agent and skill files with portable-core architecture |
+| [`api-route-governance`](api-route-governance/) | Encode API design standards — naming, versioning, errors, and payload rules |
+| [`contract-enforcement-governance`](contract-enforcement-governance/) | Catch breaking changes, enforce conformance tests, and gate CI |
+| [`database-schema-governance`](database-schema-governance/) | Enforce PostgreSQL schema standards from naming through migration safety |
+| [`developer-docs-authoring`](developer-docs-authoring/) | Design, scaffold, and audit developer documentation end-to-end |
+| [`developer-environment-authoring`](developer-environment-authoring/) | Audit, scaffold, and maintain dev environment configs |
+| [`marketing-site-authoring`](marketing-site-authoring/) | Multi-stage content pipeline from brand strategy through design audit |
+| [`musher-bundle-scaffolding`](musher-bundle-scaffolding/) | Scaffold new bundle directories with validated naming |
+| [`openapi-specification-governance`](openapi-specification-governance/) | Keep OpenAPI specs consistent, complete, and SDK-generation-ready |
+| [`product-profile-authoring`](product-profile-authoring/) | Create canonical product profiles — metadata, positioning, roadmaps |
+| [`project-shaping-orchestration`](project-shaping-orchestration/) | Shape projects before committing to build — problem framing through scoping |
+| [`repo-documentation-authoring`](repo-documentation-authoring/) | Scaffold and maintain GitHub community health files |
 
 ## SDK Examples
 

--- a/agent-asset-authoring/README.md
+++ b/agent-asset-authoring/README.md
@@ -1,21 +1,57 @@
 # Agent Asset Authoring
 
-Provides content and templates for creating agent files including skills, hooks, rules, and other agent assets.
+Generate well-structured agent and skill files with portable-core architecture and harness adapters. This bundle takes the guesswork out of creating new agent components — it produces optimized system prompts, proper frontmatter, reference file organization, and vendor adapter configurations that work across harnesses.
 
-## Metadata
+## Quick Start
 
-- **Domain:** agent-asset
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** skill-authoring, agent-skills, agent-files
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/agent-asset-authoring
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Generate a new agent for reviewing database migrations
+```
+
+## What's Inside
+
+The bundle ships two skills for generating the two most common agent asset types.
+
+The `generate-agent` skill creates project-level agents with optimized system prompts, proper tool access declarations, model selection, and context isolation patterns. It includes reference examples showing complete agent files with different specialization patterns (read-only auditors, implementers, orchestrators).
+
+The `generate-skill` skill creates portable skills following the two-layer architecture: a markdown core (SKILL.md) that works everywhere, plus optional vendor adapter configurations for harness-specific features. It covers naming conventions, trigger definitions, frontmatter structure, and reference file organization.
+
+Both skills produce assets that follow the portable-core + adapter pattern, ensuring components work across all supported harnesses rather than being locked to a single vendor.
+
+## Usage Examples
+
+**Generate a new agent**
+```
+Generate an agent for auditing TypeScript code quality — it should be read-only with access to Read, Grep, and Glob tools
+```
+Creates an agent file with system prompt, tool restrictions, model selection, and delegation patterns.
+
+**Generate a new skill**
+```
+Generate a skill for reviewing pull requests that triggers on "review PR", "code review", and "PR feedback"
+```
+Creates a SKILL.md with portable core content, trigger definitions, and adapter configuration.
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- None
 
-### Agents
-- None
+| Skill | Purpose |
+|-------|---------|
+| `generate-agent` | Create project-level agents with system prompts, tool access, and context isolation |
+| `generate-skill` | Create portable skills with markdown core, triggers, and vendor adapters |
 
-### Tools
-- None
+</details>
+
+---
+
+**Domain:** agent-asset · **Technologies:** Harness-agnostic · **Aliases:** skill-authoring, agent-skills, agent-files

--- a/api-route-governance/README.md
+++ b/api-route-governance/README.md
@@ -1,34 +1,89 @@
 # API Route Governance
 
-Enforces API endpoint design standards including route naming, HTTP method usage, request and response formats, versioning, and error response structure.
+Stop debating REST conventions. This bundle encodes API design standards so every endpoint follows the same naming, versioning, error, and payload rules — enforced by automated audits and ready-made fixes.
 
-## Metadata
+## Quick Start
 
-- **Domain:** api-route
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** api-standards, endpoint-conventions, api-design-rules
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/api-route-governance
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Audit the API routes in src/api/ for compliance with our REST conventions
+```
+
+## What's Inside
+
+The bundle ships two agents and thirteen governance skills that cover the full API design lifecycle — from URI structure through field serialization to schema implementation.
+
+The **route_auditor** agent runs read-only compliance checks against your route designs and payload contracts. It scores endpoints across URI naming, HTTP semantics, error responses, versioning, pagination, tenant routes, payload structure, field formats, and mutation patterns, then produces a severity-prioritized findings report.
+
+The **route_designer** agent picks up where the auditor leaves off. It implements fixes for governance violations, scaffolds new compliant endpoints, and refactors non-conforming routes to match your standards.
+
+Each governance skill encodes a specific domain of API design — route naming conventions, HTTP method semantics per RFC 9110, RFC 9457 Problem Details for errors, cursor-based pagination envelopes, field serialization formats (RFC 3339 timestamps, ISO 8601 durations, snake_case naming), null-vs-absent lifecycle semantics, JSON Merge Patch mutation rules, and Pydantic V2 schema implementation patterns.
+
+## Usage Examples
+
+**Run a full compliance audit**
+```
+Run a route compliance audit on our API — check naming, HTTP semantics, error responses, pagination, and payload structure
+```
+The route_auditor scans your endpoints and produces a scored findings report with severity levels and remediation guidance.
+
+**Design new endpoints**
+```
+Design the CRUD routes for a new "projects" resource following our API governance standards
+```
+The route_designer scaffolds compliant routes with proper naming, status codes, error responses, and pagination.
+
+**Review field serialization**
+```
+Review the field formats in our API responses — timestamps, money fields, enums, identifiers
+```
+Checks that your fields follow serialization conventions: RFC 3339 timestamps with `_time` suffix, embedded money objects, UPPER_SNAKE_CASE enums, and opaque string identifiers.
+
+## Boundaries
+
+This bundle governs the **route and payload layer** — URI design, HTTP semantics, request/response shapes, and framework-level schema implementation (e.g., Pydantic models).
+
+For **OpenAPI specification document** standards (metadata, operationIds, tags, component reuse, multi-file structure), see [openapi-specification-governance](../openapi-specification-governance/).
+
+For **contract enforcement pipeline** concerns (breaking change detection, conformance testing, SDK generation, CI gates), see [contract-enforcement-governance](../contract-enforcement-governance/).
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- governing-tenant-routes
-- governing-route-naming
-- governing-http-semantics
-- governing-error-responses
-- governing-api-versioning
-- governing-openapi-contracts
-- governing-collection-endpoints
-- governing-payload-structure
-- governing-field-serialization
-- governing-field-lifecycle
-- governing-mutation-semantics
-- governing-schema-implementation
-- auditing-route-compliance
+
+| Skill | Purpose |
+|-------|---------|
+| `governing-route-naming` | URI design — resource nouns, pluralization, nesting depth, kebab-case paths, UUIDs, `/me` alias |
+| `governing-http-semantics` | HTTP method safety, idempotency, status code selection per RFC 9110 |
+| `governing-error-responses` | RFC 9457 Problem Details compliance, field-level validation errors |
+| `governing-api-versioning` | Expand-and-Contract migration, deprecation headers, breaking change classification |
+| `governing-openapi-contracts` | OpenAPI metadata, operation IDs, response models, FastAPI configuration |
+| `governing-collection-endpoints` | Cursor-based pagination, page size limits, filter/sort parameters, response envelopes |
+| `governing-payload-structure` | Top-level JSON object rules, collection wrapping, I-JSON compliance per RFC 7493 |
+| `governing-field-serialization` | RFC 3339 timestamps, ISO 8601 durations, money objects, enum formats, snake_case naming |
+| `governing-field-lifecycle` | Null-vs-absent semantics, OUTPUT_ONLY/IMMUTABLE annotations, input-output model separation |
+| `governing-mutation-semantics` | PUT full replacement, JSON Merge Patch (RFC 7396), array mutation via sub-resources |
+| `governing-schema-implementation` | Pydantic V2 config, response_model enforcement, discriminated unions, model naming |
+| `governing-tenant-routes` | Multi-tenant path design, dual-validation middleware, BOLA prevention |
+| `auditing-route-compliance` | 60-question compliance audit across 5 categories with severity scoring |
 
 ### Agents
-- route_auditor
-- route_designer
 
-### Tools
-- None
+| Agent | Role |
+|-------|------|
+| `route_auditor` | Read-only compliance audits producing severity-prioritized findings reports |
+| `route_designer` | Implements fixes, scaffolds compliant endpoints, refactors non-conforming routes |
+
+</details>
+
+---
+
+**Domain:** api-route · **Technologies:** Harness-agnostic · **Aliases:** api-standards, endpoint-conventions, api-design-rules

--- a/contract-enforcement-governance/README.md
+++ b/contract-enforcement-governance/README.md
@@ -1,37 +1,82 @@
 # Contract Enforcement Governance
 
-Audits, designs, and enforces contract verification across the development pipeline — breaking change detection, conformance testing, SDK generation, CI gates, and monorepo artifact structure.
+Catch breaking changes, enforce conformance tests, and gate CI before bad contracts ship. This bundle governs the enforcement layer between your OpenAPI spec and your implementation — breaking change detection with oasdiff, conformance testing with Schemathesis, SDK generation with @hey-api/openapi-ts, and multi-stage CI pipelines.
 
-## Metadata
+## Quick Start
 
-- **Domain:** contract-enforcement
-- **Risk Level:** medium
-- **Technologies:** None (vendor-agnostic patterns; skills reference specific tools as recommended implementations)
-- **Aliases:** contract-gov, enforcement-governance, contract-pipeline
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Boundary
+```sh
+mush bundle install musher-dev/contract-enforcement-governance
+```
 
-This bundle governs the enforcement layer between specification authoring and route implementation — detecting breaks, testing conformance, generating SDKs, configuring CI gates, and structuring monorepo artifacts. For the OpenAPI specification document itself (metadata, operations, tags, components, extensions), see `openapi-specification-governance`. For framework-specific route implementation (naming, HTTP semantics, payloads, schemas), see `api-route-governance`.
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
 
-## Components
+```
+Audit our contract enforcement posture — check for breaking change detection, conformance tests, SDK generation, and CI gates
+```
+
+## What's Inside
+
+The bundle ships two agents and six skills that cover the full contract enforcement pipeline.
+
+The **contract_auditor** agent performs a read-only assessment of your enforcement posture across five dimensions: contract structure, breaking change detection, conformance testing, SDK generation, and CI pipeline completeness. It produces a severity-prioritized findings report with a maturity score and improvement roadmap.
+
+The **contract_engineer** agent implements the infrastructure that the auditor recommends — oasdiff configuration for breaking change classification, Schemathesis test scaffolding with `from_asgi()` for FastAPI, `@hey-api/openapi-ts` setup for SDK generation, CI pipeline files with blocking and warning gates, and monorepo contract package layout.
+
+The enforcement skills are organized around a 5-stage pipeline model: lint, bundle, diff, backend validate, frontend conform. Each stage can run as a blocking gate or advisory warning, with artifact passing between stages and observability hooks.
+
+## Usage Examples
+
+**Assess enforcement maturity**
+```
+Audit our contract enforcement setup — how mature is our breaking change detection, conformance testing, and CI pipeline?
+```
+The contract_auditor evaluates your posture and produces a maturity score with prioritized next steps.
+
+**Set up breaking change detection**
+```
+Configure oasdiff to detect breaking changes in our OpenAPI spec and block PRs that introduce ERR-level breaks
+```
+The contract_engineer sets up oasdiff with severity classification (ERR vs WARN), deprecation window enforcement, and CI gate configuration.
+
+**Scaffold conformance tests**
+```
+Set up Schemathesis conformance tests against our FastAPI app with stateful testing and test database management
+```
+Creates property-based contract tests that validate your implementation matches the spec, with stateful testing via OpenAPI links.
+
+## Boundaries
+
+This bundle governs the **enforcement pipeline** — the tooling and CI configuration that verifies your implementation matches your spec.
+
+For **OpenAPI specification document** standards (metadata, operationIds, tags, component reuse, multi-file structure), see [openapi-specification-governance](../openapi-specification-governance/).
+
+For **route and payload implementation** concerns (URI naming, HTTP semantics, error responses, Pydantic models), see [api-route-governance](../api-route-governance/).
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
 
-| Name | Scope |
-|------|-------|
-| `governing-contract-structure` | Monorepo workspace config (Turborepo/Nx), `packages/contract/` layout, artifact separation (editable vs generated vs implementation source) |
-| `detecting-breaking-changes` | oasdiff integration, breaking change classification (ERR/WARN), backward compatibility rules, deprecation window enforcement, CI gate config |
-| `testing-contract-conformance` | Schemathesis integration, `from_asgi()` for FastAPI, stateful testing with OpenAPI links, test DB management, state machine config |
-| `governing-sdk-generation` | @hey-api/openapi-ts config, prohibiting manual fetch wrappers, `tsc --noEmit` conformance, generated SDK consumption rules, regeneration triggers |
-| `governing-enforcement-pipeline` | 5-stage pipeline (lint, bundle, diff, backend validate, frontend conform), gate config, blocking vs warning modes |
-| `auditing-contract-enforcement` | Audit question bank across all 5 enforcement dimensions, compliance scoring, enforcement maturity assessment |
+| Skill | Purpose |
+|-------|---------|
+| `governing-contract-structure` | Monorepo layout, artifact separation (editable spec vs generated outputs), workspace config |
+| `detecting-breaking-changes` | oasdiff integration, ERR/WARN classification, deprecation windows, sunset headers, CI gates |
+| `testing-contract-conformance` | Schemathesis setup, `from_asgi()` integration, stateful testing, test DB management |
+| `governing-sdk-generation` | `@hey-api/openapi-ts` config, `tsc --noEmit` validation, consumption rules, regeneration triggers |
+| `governing-enforcement-pipeline` | 5-stage pipeline (lint → bundle → diff → validate → conform), gate modes, artifact passing |
+| `auditing-contract-enforcement` | 5-category question bank, severity model, compliance scorecard, maturity assessment |
 
 ### Agents
 
-| Name | Purpose | Model | Tools |
-|------|---------|-------|-------|
-| `contract_auditor` | Read-only audits of contract enforcement posture across break detection, test coverage, SDK generation, CI gates, repo structure | opus | Read, Grep, Glob |
-| `contract_engineer` | Implements enforcement infrastructure: oasdiff config, Schemathesis scaffolding, SDK generation config, CI pipeline files, monorepo layout | sonnet | Read, Grep, Glob, Edit, Write |
+| Agent | Role |
+|-------|------|
+| `contract_auditor` | Read-only enforcement posture audits with maturity scoring and improvement roadmap |
+| `contract_engineer` | Implements enforcement infrastructure — oasdiff, Schemathesis, SDK generation, CI pipelines |
 
-### Tools
-- None
+</details>
+
+---
+
+**Domain:** contract-enforcement · **Technologies:** oasdiff, Schemathesis, @hey-api/openapi-ts (harness-agnostic) · **Aliases:** contract-gov, enforcement-governance, contract-pipeline

--- a/database-schema-governance/README.md
+++ b/database-schema-governance/README.md
@@ -1,42 +1,111 @@
 # Database Schema Governance
 
-Enforces database design standards including table and column naming conventions, data type selection, indexing strategies, and structural patterns.
+Enforce PostgreSQL schema standards from naming conventions through migration safety and operational health. This bundle catches anti-patterns before they reach production, scores your schema against a maturity model, and helps you design tables, indexes, partitions, and multi-tenant structures that follow proven conventions.
 
-## Metadata
+## Quick Start
 
-- **Domain:** database-schema
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** db-naming-standards, schema-conventions, database-standards
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/database-schema-governance
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Audit our database schema — check naming conventions, data types, indexes, and anti-patterns
+```
+
+## What's Inside
+
+The bundle ships three agents and eighteen skills covering schema design, migration safety, operational health, and CI enforcement.
+
+The **schema_auditor** agent runs comprehensive read-only audits covering naming conventions, data type choices, anti-patterns (soft deletes, unindexed foreign keys, over-indexing, JSONB misuse, offset pagination), index strategy, documentation completeness, and overall maturity. It produces severity-prioritized findings with a maturity score on a 5-level scale (Ad-Hoc → Optimizing).
+
+The **database-designer** agent handles hands-on schema work — designing tables with proper normalization, constraints, and naming; implementing multi-tenant patterns; and configuring credential schemas with lifecycle management.
+
+The **pipeline_architect** agent focuses on CI/CD infrastructure — quality gate pipelines, SQL formatting toolchains (SQLFluff, pg_formatter), schema drift detection workflows, pre-commit hooks, and pgTAP behavioral test suites.
+
+Governance skills span the full lifecycle: entity boundary decisions (1NF-3NF, denormalization justification), data type enforcement (text over varchar, bigint for IDs, timestamptz everywhere), logic placement decisions (database constraints vs application layer), index optimization (covering indexes, HOT updates, EXPLAIN ANALYZE), migration safety (lock risk, CONCURRENTLY enforcement, expand-contract), data lifecycle (partitioning, archival, retention), and operational health monitoring (XID wraparound, autovacuum tuning, bloat detection).
+
+## Usage Examples
+
+**Score schema maturity**
+```
+Score our PostgreSQL schema against the maturity model — where are we on the Ad-Hoc to Optimizing scale?
+```
+The schema_auditor evaluates your schema across all dimensions and produces a maturity score with a prioritized improvement roadmap.
+
+**Review a migration for safety**
+```
+Review this migration for production safety — check lock risk, timeout mandates, backward compatibility, and WAL impact
+```
+Assesses whether the migration can run safely with zero downtime using expand-contract choreography.
+
+**Design a multi-tenant schema**
+```
+Design the database schema for our multi-tenant API using the User-Owned Organization model with RBAC
+```
+The database-designer creates tenant-scoped tables with proper isolation, membership, and role structures.
+
+**Detect anti-patterns**
+```
+Scan our schema for anti-patterns — soft deletes, unindexed foreign keys, over-indexing, JSONB in hot paths, offset pagination
+```
+Identifies the six most common PostgreSQL schema problems with detection methods and remediation steps.
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- implementing-tenancy-patterns
-- governing-credential-schemas
-- explaining-atlas
-- governing-naming-conventions
-- governing-data-types
-- detecting-schema-antipatterns
-- governing-logic-placement
-- reviewing-index-strategy
-- auditing-operational-health
-- governing-schema-documentation
-- scoring-schema-maturity
-- reviewing-migration-safety
-- governing-entity-boundaries
-- governing-data-lifecycle
+
+| Skill | Purpose |
+|-------|---------|
+| `governing-naming-conventions` | Table, column, PK, FK, boolean, timestamp, index, and constraint naming |
+| `governing-data-types` | text over varchar(n), bigint for IDs, timestamptz, numeric for money, enum vs lookup |
+| `governing-entity-boundaries` | Normalization diagnostics (1NF-3NF), denormalization, junction tables, table width |
+| `governing-logic-placement` | Database layer vs application layer decision matrix — triggers, RLS, constraints |
+| `governing-data-lifecycle` | Partitioning, archival, retention policies, materialized views, WAL impact |
+| `governing-credential-schemas` | Multi-tenant API credential storage — polymorphic principals, hash storage, audit trails |
+| `governing-schema-documentation` | COMMENT ON, Atlas comment attributes, custom linting rules |
+| `implementing-tenancy-patterns` | User-Owned Organization model, tenant isolation, RBAC schema, membership tables |
+| `detecting-schema-antipatterns` | Six anti-patterns — soft deletes, unindexed FKs, over-indexing, JSONB misuse, offset pagination |
+| `detecting-schema-drift` | Production drift detection, catalog-vs-VCS comparison, emergency reconciliation |
+| `reviewing-index-strategy` | Unused indexes, covering indexes, HOT updates, write amplification, EXPLAIN ANALYZE |
+| `reviewing-migration-safety` | Lock risk, timeout mandates, CONCURRENTLY enforcement, expand-contract, WAL impact |
+| `scoring-schema-maturity` | 5-level maturity model with diagnostic questions and prioritized audit checklist |
+| `auditing-operational-health` | XID wraparound, autovacuum tuning, table/index bloat, cache hit ratios, dead tuples |
+| `explaining-atlas` | Ariga Atlas concepts, CLI commands, atlas.hcl configuration, Python integration |
+| `formatting-sql` | SQLFluff, pg_formatter, atlas fmt — tool comparison, diff-quality, pre-commit hooks |
+| `enforcing-quality-gates` | 5-phase CI/CD pipeline (local → pre-commit → PR → staging → production), tool orchestration |
+| `testing-database-behavior` | pgTAP for RLS validation, trigger testing, RegreSQL for query plan baselines |
 
 ### Agents
-- database-designer
 
-### Tools
-- None
+| Agent | Role |
+|-------|------|
+| `schema_auditor` | Read-only schema audits with maturity scoring and severity-prioritized findings |
+| `database-designer` | Hands-on schema design — normalization, constraints, tenancy, credentials |
+| `pipeline_architect` | CI/CD quality gates, SQL formatting, drift detection, pgTAP test suites |
 
 ### Rules
-- database-patterns
+
+| Rule | Purpose |
+|------|---------|
+| `database-patterns` | UUID PKs, timestamp columns, soft deletes, naming conventions, pagination indexes |
 
 ### References
-- reviewing-migrations
-- data-migrations
-- migration-safety
+
+| Reference | Purpose |
+|-----------|---------|
+| `reviewing-migrations` | Migration review guidance |
+| `data-migrations` | Data migration patterns |
+| `migration-safety` | Production migration safety checklist |
+| `enforcement-policy` | Schema governance enforcement policy |
+| `tooling-ecosystem` | Tool comparison and ecosystem overview |
+
+</details>
+
+---
+
+**Domain:** database-schema · **Technologies:** PostgreSQL (harness-agnostic) · **Aliases:** db-naming-standards, schema-conventions, database-standards

--- a/developer-docs-authoring/README.md
+++ b/developer-docs-authoring/README.md
@@ -1,40 +1,95 @@
 # Developer Docs Authoring
 
-Skills and agents for generating, maintaining, editing, and auditing developer user documentation.
+Design, scaffold, and audit developer documentation — from navigation architecture and page structure to content quality scoring and accessibility compliance. This bundle covers the full documentation lifecycle with specialized agents for structure, clarity, scaffolding, quality gating, LLM indexing, and site-wide architecture analysis.
 
-## Metadata
+## Quick Start
 
-- **Domain:** developer-docs
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** dev-docs, docs-authoring, developer-documentation
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/developer-docs-authoring
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Audit our developer docs site — check navigation, content quality, accessibility, and coverage gaps
+```
+
+## What's Inside
+
+The bundle ships six agents and fifteen skills that cover documentation design, generation, and quality assurance.
+
+The **docs-designer** agent is the primary workhorse — it audits and designs technical documentation for structure, clarity, user empathy, and Diataxis compliance. The **concept-designer** focuses specifically on terminology consistency and cognitive load, ensuring primitives are explained clearly and concepts build on each other.
+
+The **page-scaffolder** agent generates structurally correct pages from Diataxis-aligned archetypes (Quickstart, How-To, API Reference, Webhooks, Troubleshooting) with production-quality code displays. The **quality-reviewer** scores finished pages against a 5-dimension rubric (Findability, Accuracy, Clarity, Task Orientation, Readability) and issues pass/fail verdicts as a pre-publish gate.
+
+The **site-architect** agent analyzes the full documentation site for content coverage gaps, cross-section navigation coherence, sitemap completeness, orphan pages, and end-to-end user journey tracing. The **index-generator** produces machine-readable `llms.txt` and `llms-full.txt` files optimized for AI assistant consumption and RAG ingestion.
+
+Skills cover navigation systems (three-pane layouts, sidebar governance, breadcrumbs), taxonomy decisions, search/discovery UX, onboarding journey design, code display patterns, typography standards, accessibility compliance, versioning documentation, lifecycle governance, and benchmarking against industry leaders like Stripe, Vercel, and Kubernetes.
+
+## Usage Examples
+
+**Audit documentation quality**
+```
+Score our API reference pages against the editorial quality rubric — check findability, accuracy, clarity, and readability
+```
+The quality-reviewer produces dimension scores and a pass/fail verdict with specific remediation guidance.
+
+**Scaffold a new quickstart page**
+```
+Scaffold a quickstart page for our Python SDK with Diataxis-aligned structure and working code examples
+```
+The page-scaffolder generates a structurally correct page with proper anatomy for the quickstart archetype.
+
+**Find coverage gaps**
+```
+Analyze our docs site architecture — find orphan pages, coverage gaps, and broken navigation paths
+```
+The site-architect maps the full content graph and identifies structural issues.
+
+**Design the docs landing page**
+```
+Design the landing page for our developer docs — hero section, self-selection routing, getting-started block, and trust signals
+```
+Applies the 7-section landing page blueprint with hello-world visuals and persona-based routing.
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- **designing-landing-pages** — Docs landing page architecture: hero section, hello-world visual, self-selection routing, getting-started block, architecture overview, community/support, trust signals
-- **designing-navigation-systems** — Navigation architecture: three-pane layout, sidebar governance (20-item rule), breadcrumbs, contextual nav switching, Hick's Law, depth limits
-- **governing-taxonomy** — Taxonomy decisions: task-based vs topic-based, hybrid model, split/nest rules, content model metadata schema, controlled vocabulary
-- **auditing-docs-metrics** — Documentation KPIs: TTFS, search-to-click ratio, zero-result rate, bounce rate, deflection, usability testing (NASA-TLX)
-- **designing-search-discovery** — Search UX: federated search, scoped search, CMD+K pattern, synonym handling, zero-result recovery, search analytics feedback loop
-- **governing-docs-lifecycle** — Scaling governance: docs-as-code workflows, quarterly content audits, page lifecycle states, stale content detection, contributor onboarding
-- **analyzing-docs-benchmarks** — Benchmark analysis: Stripe/Vercel/K8s/AWS pattern extraction, innovation catalog, anti-pattern catalog, scorecard template
-- **scaffolding-page-archetypes** — Page archetype anatomy: Quickstart, How-To, API Reference, Webhooks, Troubleshooting structural templates with Diataxis alignment
-- **designing-code-displays** — Code block UX: syntax highlighting, copy buttons, language tab sync, interactive playgrounds, dynamic API key injection, CI-verified examples
-- **generating-llm-indexes** — Machine-readable docs: llms.txt architecture map, llms-full.txt content dump, AI assistant optimization, update cadence
-- **auditing-content-quality** — Editorial quality rubric: Findability, Accuracy, Clarity, Task Orientation, Readability scoring with pre-launch validation checklist
-- **designing-typography-layout** — Typography standards: line length 45-90 chars, leading 1.5x, baseline grid, whitespace density, heading hierarchy, density per page type
-- **auditing-accessibility-compliance** — WCAG AA evaluation for docs sites: keyboard navigation, screen reader compatibility, color contrast, ARIA attributes, skip navigation, focus management
-- **designing-onboarding-journeys** — Multi-page onboarding flow design: TTFS optimization, progressive complexity curves, persona-based path branching, milestone placement, page-type handoff patterns
-- **governing-version-migrations** — Version documentation governance: changelog formats, deprecation notice standards, migration guide anatomy, version selector UX, multi-version docs management
+
+| Skill | Purpose |
+|-------|---------|
+| `designing-landing-pages` | Docs landing page architecture — hero, self-selection, getting-started, trust signals |
+| `designing-navigation-systems` | Three-pane layout, sidebar governance, breadcrumbs, contextual nav switching |
+| `governing-taxonomy` | Task-based vs topic-based categorization, hybrid models, split/nest rules |
+| `auditing-docs-metrics` | KPIs — TTFS, search-to-click ratio, zero-result rate, bounce rate, usability testing |
+| `designing-search-discovery` | Federated search, CMD+K, synonym handling, zero-result recovery |
+| `governing-docs-lifecycle` | Docs-as-code workflows, quarterly audits, page lifecycle states, stale detection |
+| `analyzing-docs-benchmarks` | Benchmark against Stripe/Vercel/K8s/AWS with pattern extraction and scorecards |
+| `scaffolding-page-archetypes` | Diataxis-aligned structural templates — Quickstart, How-To, Reference, Webhooks, Troubleshooting |
+| `designing-code-displays` | Syntax highlighting, copy buttons, language tabs, interactive playgrounds, API key injection |
+| `generating-llm-indexes` | `llms.txt` / `llms-full.txt` generation for AI assistant consumption and RAG |
+| `auditing-content-quality` | 5-dimension editorial rubric with pre-launch validation checklist |
+| `designing-typography-layout` | Line length, leading, baseline grid, whitespace density, heading hierarchy |
+| `auditing-accessibility-compliance` | WCAG AA — keyboard navigation, screen readers, color contrast, ARIA, focus management |
+| `designing-onboarding-journeys` | Multi-page flows, progressive complexity, persona branching, TTFS optimization |
+| `governing-version-migrations` | Changelog formats, deprecation notices, migration guides, version selector UX |
 
 ### Agents
-- **docs-designer** — Audit and design technical documentation for structure, clarity, user empathy, and Diataxis compliance
-- **concept-designer** — Audit and improve concept clarity, terminology consistency, and cognitive load management
-- **page-scaffolder** — Generate structurally correct documentation pages from Diataxis-aligned archetypes with production-quality code displays
-- **quality-reviewer** — Score documentation pages against a 5-dimension editorial quality rubric and issue pre-publish pass/fail verdicts
-- **index-generator** — Generate site-wide machine-readable documentation indexes (llms.txt, llms-full.txt) for AI assistant consumption
-- **site-architect** — Analyze docs site architecture for content coverage gaps, cross-section navigation coherence, sitemap completeness, section balance, orphan page detection, and user journey tracing
 
-### Tools
-- None
+| Agent | Role |
+|-------|------|
+| `docs-designer` | Audits and designs documentation structure, clarity, and Diataxis compliance |
+| `concept-designer` | Improves concept clarity, terminology consistency, and cognitive load |
+| `page-scaffolder` | Generates structurally correct pages from Diataxis archetypes |
+| `quality-reviewer` | Scores pages against 5-dimension rubric, issues pre-publish pass/fail |
+| `index-generator` | Produces `llms.txt` / `llms-full.txt` machine-readable indexes |
+| `site-architect` | Analyzes site-wide coverage, navigation coherence, and user journeys |
+
+</details>
+
+---
+
+**Domain:** developer-docs · **Technologies:** Harness-agnostic · **Aliases:** dev-docs, docs-authoring, developer-documentation

--- a/developer-environment-authoring/README.md
+++ b/developer-environment-authoring/README.md
@@ -1,40 +1,101 @@
 # Developer Environment Authoring
 
-Provides knowledge and templates for authoring developer environment configurations including devcontainers, task runners, and workspace setup.
+Audit, scaffold, and maintain dev environment configs — devcontainers, task runners, version managers, Docker Compose, editor settings, and CI alignment. This bundle finds the gaps in your developer experience setup, generates the missing configuration, and verifies everything works together.
 
-## Metadata
+## Quick Start
 
-- **Domain:** developer-environment
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** dev-env, devcontainer-authoring, workspace-setup
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/developer-environment-authoring
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Audit our dev environment setup and tell me what's missing
+```
+
+## What's Inside
+
+The bundle ships three agents and ten skills following an audit → scaffold → verify workflow.
+
+The **environment_auditor** agent runs a read-only assessment of your repository's developer environment configuration across eight dimensions — devcontainers, toolchain versions, task runners, environment variables, editor settings, Docker setup, CI alignment, and workspace initialization. It produces a gap analysis with a maturity score on a 5-level scale (Ad Hoc → CI-Aligned).
+
+The **environment_scaffolder** agent generates complete configuration files from audit findings or from scratch — `devcontainer.json`, `Taskfile.yml`, `docker-compose.yml`, `.tool-versions`, `.env.example`, `.editorconfig`, and workspace setup scripts.
+
+The **devcontainer_specialist** agent handles complex container environments — multi-container setups, feature composition, lifecycle hook debugging, and Docker-in-Docker configurations.
+
+The `orchestrating-environment-setup` skill coordinates the full workflow: audit the current state, plan what to generate, delegate to the scaffolder, and verify the results.
+
+## Usage Examples
+
+**Audit environment completeness**
+```
+Audit this repo's developer environment — score devcontainer, toolchain versions, task runner, env vars, editor settings, Docker, and CI alignment
+```
+The environment_auditor produces a maturity-scored gap analysis with prioritized remediation steps.
+
+**Scaffold a devcontainer**
+```
+Create a devcontainer configuration for this Python/Node project with PostgreSQL and Redis services
+```
+The devcontainer_specialist generates `devcontainer.json` with features, lifecycle hooks, and Docker Compose integration.
+
+**Set up the full dev environment**
+```
+Run the full environment setup — audit what we have, scaffold what's missing, and verify everything works together
+```
+The orchestrator coordinates audit, planning, generation, and verification end-to-end.
+
+**Align local and CI environments**
+```
+Make sure our local dev environment matches CI — check version files, lock files, and devcontainer reuse
+```
+Identifies parity gaps between local development and CI/CD environments.
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- `configuring-devcontainers` — devcontainer.json design, features, lifecycle hooks, Docker integration
-- `managing-toolchain-versions` — .tool-versions, .nvmrc, asdf/mise, version pinning and conflict resolution
-- `authoring-task-runners` — Taskfile.yml, Makefile, justfile, npm scripts patterns and conventions
-- `managing-environment-variables` — .env.example templates, direnv, secret classification, startup validation
-- `configuring-editor-settings` — .editorconfig, VS Code workspace settings, extensions, debug configs
-- `scaffolding-workspace-setup` — setup scripts, onboarding automation, prerequisite verification
-- `composing-docker-development` — Docker Compose for local dev, multi-stage Dockerfiles, volume strategy
-- `aligning-ci-environments` — local/CI parity, version file reads, frozen lock files, devcontainer reuse
-- `auditing-environment-completeness` — gap analysis, 8-dimension scoring, maturity assessment
-- `orchestrating-environment-setup` — end-to-end workflow: audit, plan, generate, verify
+
+| Skill | Purpose |
+|-------|---------|
+| `configuring-devcontainers` | devcontainer.json design, features, lifecycle hooks, Docker integration |
+| `managing-toolchain-versions` | `.tool-versions`, `.nvmrc`, asdf/mise, version pinning and conflict resolution |
+| `authoring-task-runners` | Taskfile.yml, Makefile, justfile, npm scripts patterns |
+| `managing-environment-variables` | `.env.example` templates, direnv, secret classification, startup validation |
+| `configuring-editor-settings` | `.editorconfig`, VS Code workspace settings, extensions, debug configs |
+| `scaffolding-workspace-setup` | Setup scripts, onboarding automation, prerequisite verification |
+| `composing-docker-development` | Docker Compose for local dev, multi-stage Dockerfiles, volume strategy |
+| `aligning-ci-environments` | Local/CI parity, version file reads, frozen lock files, devcontainer reuse |
+| `auditing-environment-completeness` | 8-dimension gap analysis with maturity scoring |
+| `orchestrating-environment-setup` | End-to-end workflow: audit → plan → generate → verify |
 
 ### Agents
-- `environment_auditor` — read-only auditor producing maturity-scored gap analysis reports
-- `environment_scaffolder` — generates complete environment configuration from audit findings or from scratch
-- `devcontainer_specialist` — deep-focus expert for complex container environments and troubleshooting
+
+| Agent | Role |
+|-------|------|
+| `environment_auditor` | Read-only maturity-scored gap analysis across 8 dimensions |
+| `environment_scaffolder` | Generates complete environment configuration from audit findings |
+| `devcontainer_specialist` | Deep-focus expert for complex container environments and troubleshooting |
 
 ### Rules
-- `environment-config-patterns` — enforcement rules for devcontainer, Docker, version, env var, and editor config files
+
+| Rule | Purpose |
+|------|---------|
+| `environment-config-patterns` | Enforcement rules for devcontainer, Docker, version, env var, and editor configs |
 
 ### References
-- `configuration-file-catalog` — canonical catalog of ~30 developer environment config files
-- `tooling-ecosystem` — comparative analysis of version managers, task runners, container tools
-- `environment-maturity-model` — 5-level maturity framework (Ad Hoc → CI-Aligned)
 
-### Tools
-- None
+| Reference | Purpose |
+|-----------|---------|
+| `configuration-file-catalog` | Canonical catalog of ~30 developer environment config files |
+| `tooling-ecosystem` | Comparative analysis of version managers, task runners, container tools |
+| `environment-maturity-model` | 5-level maturity framework (Ad Hoc → CI-Aligned) |
+
+</details>
+
+---
+
+**Domain:** developer-environment · **Technologies:** Harness-agnostic · **Aliases:** dev-env, devcontainer-authoring, workspace-setup

--- a/marketing-site-authoring/README.md
+++ b/marketing-site-authoring/README.md
@@ -1,48 +1,107 @@
 # Marketing Site Authoring
 
-Orchestrates a multi-agent pipeline for marketing site content production including brand strategy, information architecture, copy writing, editorial review, page implementation, and design compliance auditing. Introduces the marketing-site domain term.
+Run a multi-stage content pipeline from brand strategy through page implementation and design audit. This bundle orchestrates the full journey — competitive analysis, brand positioning, information architecture, wireframe copy, editorial review, component scaffolding, page assembly, animation, and compliance auditing — with specialized agents at each stage.
 
-## Metadata
+## Quick Start
 
-- **Domain:** marketing-site
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** marketing, marketing-site, landing-page
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/marketing-site-authoring
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Run the marketing content pipeline for our landing page, starting from our brand packet
+```
+
+## What's Inside
+
+The bundle ships nine agents and twenty skills organized around a multi-stage production pipeline.
+
+**Stage 1 — Brand Strategy.** Skills for competitive analysis, brand positioning, voice definition, visual identity, and trust signal sourcing feed into a validated Brand Packet. The `validating-brand-packets` skill gates quality before proceeding.
+
+**Stage 2 — Information Architecture.** The **ia_producer** agent transforms the Brand Packet into a section-by-section IA document defining narrative flow, layout patterns, and conversion strategy.
+
+**Stage 3 — Copy Production.** The **copy_writer** agent drafts marketing copy using cognitive science principles. The **copy_producer** fills every content slot defined in the IA. The **copy_reviewer** runs an anti-generic editorial pass, stripping banned vocabulary, filler, and hyperbolic claims.
+
+**Stage 4 — Implementation.** The **section_builder** scaffolds Svelte 5 components from IA definitions. The **animation_engineer** adds scroll-triggered animations. The **page_assembler** composes sections into SvelteKit page routes with SEO meta tags.
+
+**Stage 5 — Quality Assurance.** The **design_auditor** scans components for design system compliance. The **ux_auditor** evaluates information architecture, component presence, and trust signals.
+
+Three orchestration skills (`orchestrating-content-pipeline`, `orchestrating-site-implementation`, `orchestrating-page-review`) coordinate agents across stages with approval gates between them.
+
+## Usage Examples
+
+**Run the full content pipeline**
+```
+Run the marketing content pipeline from brand packet through IA, wireframe copy, and editorial review
+```
+Orchestrates stages 1-3 sequentially with user approval gates between stages.
+
+**Build and audit the site**
+```
+Implement the landing page — build section components, add animations, assemble the page, and audit for design compliance
+```
+Orchestrates stages 4-5: scaffolding, animation, assembly, and compliance audit.
+
+**Review an existing page**
+```
+Run a comprehensive review of our landing page — check copy, UX, components, and trust signals
+```
+Delegates to specialized agents for deep analysis across copy quality, UX patterns, and design compliance.
+
+**Analyze a competitor**
+```
+Deconstruct stripe.com's marketing site — hero patterns, copy strategy, trust signals, design system, and tech stack
+```
+Produces a structured 5-dimension competitive analysis.
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- analyzing-competitors
-- animating-scroll-reveals
-- assembling-pages
-- auditing-design-compliance
-- auditing-page-velocity
-- auditing-trust-engineering
-- building-code-displays
-- generating-design-rules
-- orchestrating-content-pipeline
-- orchestrating-page-review
-- orchestrating-site-implementation
-- reviewing-copy
-- scaffolding-sections
-- validating-brand-packets
-- writing-brand-positioning
-- writing-brand-voice
-- writing-information-architecture
-- writing-trust-signals
-- writing-visual-identity
-- writing-wireframe-copy
+
+| Skill | Purpose |
+|-------|---------|
+| `analyzing-competitors` | Deconstruct competitor sites across 5 dimensions |
+| `writing-brand-positioning` | Positioning statements, ICP profiles, differentiators |
+| `writing-brand-voice` | Tonal boundaries, vibe/anti-vibe adjectives, banned vocabulary |
+| `writing-visual-identity` | Color tokens, typography system, spatial rules |
+| `writing-trust-signals` | Metrics, logos, badges, quotes, community signals |
+| `validating-brand-packets` | 11-field completeness check, 6-dimension Polish rubric |
+| `writing-information-architecture` | Section-by-section IA with narrative flow and conversion strategy |
+| `writing-wireframe-copy` | Exact copy for every content slot from the IA document |
+| `reviewing-copy` | Anti-generic editorial pass — banned vocabulary, filler, hyperbole |
+| `scaffolding-sections` | IA definitions to Svelte 5 components with design tokens |
+| `building-code-displays` | Marketing-grade code blocks with syntax highlighting and terminal chrome |
+| `animating-scroll-reveals` | CSS `.reveal` classes or GSAP ScrollTrigger patterns |
+| `assembling-pages` | SvelteKit page routes with SEO meta, section ordering, anchor nav |
+| `generating-design-rules` | Design system enforcement rules for the harness |
+| `auditing-design-compliance` | Automated grep scans for token, typography, and spacing violations |
+| `auditing-page-velocity` | Core Web Vitals compliance and perceived performance |
+| `auditing-trust-engineering` | Privacy-first trust architecture and consent UX |
+| `orchestrating-content-pipeline` | Brand → IA → copy → editorial pipeline orchestration |
+| `orchestrating-site-implementation` | Build → animate → assemble → audit pipeline orchestration |
+| `orchestrating-page-review` | Comprehensive review across copy, UX, components, and trust |
 
 ### Agents
-- animation_engineer
-- copy_producer
-- copy_reviewer
-- copy_writer
-- design_auditor
-- ia_producer
-- page_assembler
-- section_builder
-- ux_auditor
 
-### Tools
-- None
+| Agent | Role |
+|-------|------|
+| `ia_producer` | Transforms Brand Packet into structural IA blueprint |
+| `copy_writer` | Drafts marketing copy using cognitive science principles |
+| `copy_producer` | Fills content slots from IA with 90%-final wireframe copy |
+| `copy_reviewer` | Anti-generic editorial pass stripping banned vocabulary and filler |
+| `section_builder` | Builds Svelte 5 section components from IA and copy |
+| `animation_engineer` | Adds scroll-triggered animations to section components |
+| `page_assembler` | Composes sections into SvelteKit page routes with SEO |
+| `design_auditor` | Scans components for design system compliance violations |
+| `ux_auditor` | Audits page UX, information architecture, and visual system |
+
+</details>
+
+---
+
+**Domain:** marketing-site · **Technologies:** Harness-agnostic · **Aliases:** marketing, marketing-site, landing-page

--- a/musher-bundle-scaffolding/README.md
+++ b/musher-bundle-scaffolding/README.md
@@ -1,21 +1,54 @@
 # Musher Bundle Scaffolding
 
-Scaffolds new bundle directories with naming validation, manifests, and standard structure for the musher platform.
+Scaffold new bundle directories with validated naming and standard structure. This skill enforces the bundle naming grammar (`[technology]-[domain]-[purpose]`), scores proposed names against a 12-point evaluation rubric, and creates the directory with a properly structured README.
 
-## Metadata
+## Quick Start
 
-- **Domain:** bundle
-- **Risk Level:** low
-- **Technologies:** musher
-- **Aliases:** bundle-creator, scaffold-bundle, new-bundle
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/musher-bundle-scaffolding
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+/create-bundle
+```
+
+## Usage Examples
+
+**Scaffold a new bundle**
+```
+Create a new bundle for Terraform infrastructure governance
+```
+Validates the name against the rubric (must score 10+/12), creates the directory, and generates the README with proper metadata.
+
+**Validate a bundle name**
+```
+Would "terraform-infrastructure-governance" be a good bundle name? Score it against the rubric.
+```
+Evaluates distinctiveness, breadth signaling, discoverability, and consistency before committing to a name.
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- creating-bundle
 
-### Agents
-- None
+| Skill | Purpose |
+|-------|---------|
+| `create-bundle` | Scaffold bundle directory with naming validation and README generation |
 
-### Tools
-- None
+### References
+
+| Reference | Purpose |
+|-----------|---------|
+| `naming-grammar` | Controlled vocabulary for domain and purpose segments |
+| `evaluation-rubric` | 4-criteria scoring (distinctiveness, breadth, discoverability, consistency) |
+| `bundle-readme-template` | Standard README structure for new bundles |
+
+</details>
+
+---
+
+**Domain:** bundle · **Technologies:** Musher · **Aliases:** bundle-creator, scaffold-bundle, new-bundle

--- a/openapi-specification-governance/README.md
+++ b/openapi-specification-governance/README.md
@@ -1,41 +1,86 @@
 # OpenAPI Specification Governance
 
-Audits, authors, and enforces OpenAPI specifications for standards compliance and contract quality.
+Keep your OpenAPI specs consistent, complete, and SDK-generation-ready. This bundle governs the specification document itself — metadata, operation identifiers, tag taxonomy, component reuse, multi-file structure, and change workflows — with automated audits and hands-on fixes.
 
-## Metadata
+## Quick Start
 
-- **Domain:** specification
-- **Risk Level:** medium
-- **Technologies:** OpenAPI
-- **Aliases:** openapi-gov, oas-governance, openapi-spec
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Boundary
+```sh
+mush bundle install musher-dev/openapi-specification-governance
+```
 
-This bundle governs the OpenAPI specification document itself, framework-agnostic. For framework-specific code configuration (e.g., FastAPI route decorators, Pydantic models, `root_path`), see `api-route-governance`.
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
 
-## Components
+```
+Audit our OpenAPI spec for compliance — check metadata, operationIds, tags, component reuse, and structure
+```
+
+## What's Inside
+
+The bundle ships two agents and ten governance skills focused exclusively on the OpenAPI specification document.
+
+The **spec_auditor** agent performs read-only analysis across nine compliance categories — spec metadata, operation identifiers, tag hierarchy, component reuse, advanced operations, extension governance, spec structure, authoring model, and change workflow — then produces a scored findings report with a compliance scorecard.
+
+The **spec_designer** agent implements fixes for audit findings, scaffolds compliant specification files, and refactors non-conforming specs to meet governance standards.
+
+The governance skills cover the full specification lifecycle: Info object completeness and LLM-readable descriptions, camelCase operationId naming with SDK generation impact, hierarchical tag taxonomy (OpenAPI 3.2.0), `$ref` patterns and schema composition with `allOf`/`oneOf`/discriminator, multi-file directory layout with Redocly bundling, design-first vs code-first authoring evaluation, and the Golden Path change workflow from design through deployment.
+
+## Usage Examples
+
+**Audit an existing spec**
+```
+Run a spec compliance audit on openapi.yaml — score metadata, operationIds, tags, components, and structure
+```
+The spec_auditor produces a 9-category compliance scorecard with severity-prioritized findings.
+
+**Organize a multi-file spec**
+```
+Restructure our monolithic openapi.yaml into a multi-file layout with separate paths/, schemas/, and parameters/ directories
+```
+The spec_designer splits the spec following directory conventions and wires up `$ref` pointers.
+
+**Evaluate your authoring model**
+```
+Should we use design-first or code-first for our API spec? Evaluate the trade-offs for our team
+```
+Assesses maintenance tax, authority flow, and source-of-truth governance to recommend the right approach.
+
+## Boundaries
+
+This bundle governs the **OpenAPI specification document** — the YAML/JSON files that define your API contract.
+
+For **route and payload implementation** concerns (URI naming, HTTP semantics, error responses, Pydantic models), see [api-route-governance](../api-route-governance/).
+
+For **contract enforcement pipeline** concerns (breaking change detection, conformance testing, SDK generation, CI gates), see [contract-enforcement-governance](../contract-enforcement-governance/).
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
 
-| Name | Scope |
-|------|-------|
-| `governing-spec-metadata` | Info object completeness, `openapi` vs `info.version` versioning, servers array, organizational extensions, LLM-readable descriptions, `externalDocs` |
-| `governing-operation-identifiers` | `operationId` naming (camelCase verbNoun), uniqueness, component key regex, schema naming (UpperCamelCase), parameter naming, SDK generation impact |
-| `governing-tag-hierarchy` | 3.2.0 hierarchical tags, tag classification (navigation/badge/lifecycle/audience), migration from flat tags and `x-tagGroups` |
-| `governing-component-reuse` | `$ref` patterns, inline schema anti-patterns, schema composition (`allOf`/`oneOf`/`discriminator`), RFC 9457 ProblemDetails, SDK generation impact |
-| `governing-advanced-operations` | QUERY method via `additionalOperations`, webhooks vs callbacks, streaming media types, `itemSchema`, link objects, Overlay specification |
-| `governing-spec-extensions` | `x-` prefix rules, extension governance, portability impact, standards-over-extensions philosophy, deprecating extensions |
-| `governing-spec-structure` | Multi-file spec directory layout (`paths/`, `components/`), file-level `$ref` strategies, bundling with Redocly CLI, split vs monolithic anti-patterns, root file conventions |
-| `governing-authoring-model` | Design-first vs code-first vs hybrid evaluation criteria, unidirectional authority flow, dual-schema maintenance tax, source-of-truth governance policy |
-| `governing-change-workflow` | Golden Path sequence (design → generate → implement → verify → deploy), cross-team coordination, spec-change PR conventions, backward-compatible change techniques |
-| `auditing-spec-compliance` | 9-category question bank, severity model (Critical/Major/Minor/Cosmetic), compliance scorecard, Spectral/Redocly/Vacuum rulesets, CI integration |
+| Skill | Purpose |
+|-------|---------|
+| `governing-spec-metadata` | Info object completeness, servers array, organizational extensions, LLM-readable descriptions |
+| `governing-operation-identifiers` | operationId naming (camelCase verbNoun), uniqueness, SDK generation impact |
+| `governing-tag-hierarchy` | OpenAPI 3.2.0 hierarchical tags, classification types, migration from flat tags |
+| `governing-component-reuse` | `$ref` patterns, inline schema anti-patterns, schema composition, RFC 9457 ProblemDetails |
+| `governing-advanced-operations` | QUERY method, webhooks vs callbacks, streaming media types, link objects, Overlay spec |
+| `governing-spec-extensions` | `x-` prefix conventions, portability assessment, extension registry governance |
+| `governing-spec-structure` | Multi-file directory layout, file-level `$ref` strategies, Redocly CLI bundling |
+| `governing-authoring-model` | Design-first vs code-first vs hybrid evaluation, source-of-truth governance |
+| `governing-change-workflow` | Golden Path sequence, cross-team coordination, PR conventions, backward compatibility |
+| `auditing-spec-compliance` | 9-category compliance audit with severity scoring and Spectral/Redocly/Vacuum recommendations |
 
 ### Agents
 
-| Name | Purpose | Model | Tools |
-|------|---------|-------|-------|
-| `spec_auditor` | Read-only specification audits with compliance scoring | opus | Read, Grep, Glob |
-| `spec_designer` | Specification authoring, fixing violations, scaffolding | sonnet | Read, Grep, Glob, Edit, Write |
+| Agent | Role |
+|-------|------|
+| `spec_auditor` | Read-only specification audits with compliance scorecard and improvement roadmap |
+| `spec_designer` | Implements spec fixes, scaffolds compliant files, refactors non-conforming specifications |
 
-### Tools
-- None
+</details>
+
+---
+
+**Domain:** specification · **Technologies:** OpenAPI (harness-agnostic) · **Aliases:** openapi-gov, oas-governance, openapi-spec

--- a/product-profile-authoring/README.md
+++ b/product-profile-authoring/README.md
@@ -1,26 +1,75 @@
 # Product Profile Authoring
 
-Skills for authoring and maintaining canonical product profile directories containing machine-readable metadata, strategic positioning, roadmaps, and technical specifications.
+Create canonical product profiles — metadata, positioning, roadmaps, and technical specs in structured formats. This bundle scaffolds a product profile directory and populates it with machine-readable metadata (Schema.org-aligned YAML), strategic positioning (April Dunford's framework), product overviews (Amazon Working Backwards PR/FAQ), temporal roadmaps (Now/Next/Later), and technical specifications.
 
-## Metadata
+## Quick Start
 
-- **Domain:** product-profile
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** product-docs, profile-authoring, product-profiles
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/product-profile-authoring
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Scaffold a product profile directory for our new API platform
+```
+
+## What's Inside
+
+The bundle ships six skills that together produce a complete product profile directory. There are no agents — each skill is invoked directly.
+
+The `scaffolding-product-profiles` skill creates the directory structure with template files. From there, each writing skill fills a specific document:
+
+- **product.yaml** — Machine-readable canonical metadata aligned with Schema.org fields: identity, audiences, capabilities, differentiators, integrations, and compliance posture.
+- **overview.md** — One-page product summary using the Amazon Working Backwards PR/FAQ format with press release structure, external FAQ, and internal FAQ.
+- **positioning.md** — Strategic positioning using April Dunford's 5-component framework: competitive alternatives, differentiated capabilities, customer value, target segments, and market category.
+- **roadmap.md** — Temporal planning using the Now/Next/Later format with three time-horizon buckets, dependencies, assumptions, and open questions.
+- **technical.md** — Technical specification covering architecture overview, integrations, data flows, system limits, compliance posture, and non-functional requirements.
+
+## Usage Examples
+
+**Scaffold a new product profile**
+```
+Scaffold a product profile directory for our deployment platform with all template files
+```
+Creates the directory structure with starter templates for all five documents.
+
+**Write product positioning**
+```
+Write positioning for our API gateway — identify competitive alternatives, differentiated capabilities, and target segments
+```
+Produces a structured positioning document using April Dunford's framework.
+
+**Create a product roadmap**
+```
+Create a Now/Next/Later roadmap for our developer tools platform
+```
+Organizes priorities into three time-horizon buckets with dependencies and open questions.
+
+**Write a PR/FAQ overview**
+```
+Write a Working Backwards PR/FAQ for our new observability product
+```
+Produces a press release, external FAQ (customer questions), and internal FAQ (stakeholder questions).
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- `scaffolding-product-profiles` — Scaffold a new product profile directory with template files
-- `writing-product-metadata` — Author product.yaml with Schema.org-aligned canonical metadata
-- `writing-product-overviews` — Author overview.md using Amazon Working Backwards PR/FAQ format
-- `writing-product-positioning` — Author positioning.md using April Dunford's 5-component framework
-- `writing-product-roadmaps` — Author roadmap.md using Now/Next/Later temporal planning
-- `writing-technical-specifications` — Author technical.md covering architecture, integrations, and compliance
 
-### Agents
-- None
+| Skill | Purpose |
+|-------|---------|
+| `scaffolding-product-profiles` | Scaffold directory structure with template files |
+| `writing-product-metadata` | Schema.org-aligned product.yaml — identity, audiences, capabilities, compliance |
+| `writing-product-overviews` | Amazon Working Backwards PR/FAQ format — press release, external FAQ, internal FAQ |
+| `writing-product-positioning` | April Dunford's 5-component framework — alternatives, capabilities, value, segments, category |
+| `writing-product-roadmaps` | Now/Next/Later temporal planning — three horizons, dependencies, open questions |
+| `writing-technical-specifications` | Architecture, integrations, data flows, system limits, compliance, non-functional requirements |
 
-### Tools
-- None
+</details>
+
+---
+
+**Domain:** product-profile · **Technologies:** Harness-agnostic · **Aliases:** product-docs, profile-authoring, product-profiles

--- a/project-shaping-orchestration/README.md
+++ b/project-shaping-orchestration/README.md
@@ -1,40 +1,99 @@
 # Project Shaping Orchestration
 
-Orchestrates a multi-agent pipeline for upstream project shaping including problem framing, solution design, risk assessment, and scope definition prior to build commitment.
+Shape projects before committing to build. This bundle orchestrates a multi-agent pipeline that takes raw project ideas through structured problem framing, solution design, risk assessment, and scoping — producing decision-ready artifacts like Pitches, Architecture Sketches, and Milestone Maps that can be exported directly to Linear.
 
-## Metadata
+## Quick Start
 
-- **Domain:** project-shaping
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** shaping, shape-up, project-shaping
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/project-shaping-orchestration
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Shape this project idea: [describe the feature or initiative you want to build]
+```
+
+## What's Inside
+
+The bundle ships six agents and fifteen skills organized as a sequential shaping pipeline. Each agent produces specific artifacts that feed into the next stage.
+
+**Stage 1 — Analysis.** The **shaping-analyst** takes raw project input and produces a **Context Brief** (structured facts, glossary, assumptions, unknowns) and a **Problem Frame** (trigger, impact, success criteria, appetite, non-goals).
+
+**Stage 2 — Design.** The **shaping-designer** translates the problem into concrete user interactions, producing **Domain Scenarios** (personas, workflows, edge cases, domain vocabulary) and **UX Breadboards** (user flows, screen states, error states, navigation maps).
+
+**Stage 3 — Architecture.** The **shaping-architect** maps the technical shape of the solution, producing an **Architecture Sketch** (components, data shapes, integration points, hard parts) and a **Risk Register** (rabbit holes, external dependencies, unknowables, fallback plans).
+
+**Stage 4 — Strategy.** The **shaping-strategist** synthesizes all upstream artifacts into a persuasive **Pitch** and an actionable **Milestone Map** with phased exit criteria.
+
+**Stage 5 — Review.** The **shaping-reviewer** validates artifacts against quality standards across six dimensions: API contracts, data models, security, test strategy, release plans, and codebase fit.
+
+**Stage 6 — Export.** The **shaping-formatter** transforms completed artifacts into a structured **Linear Output Package** with project configuration, milestones, and starter issues.
+
+## Usage Examples
+
+**Shape a new feature end-to-end**
+```
+Shape this project: We need to add team-based permissions to our API so organizations can control member access to resources
+```
+Runs the full pipeline from context brief through pitch and milestone map.
+
+**Review a shaped project**
+```
+Review the architecture sketch and API contracts in our shaping artifacts for security, testability, and codebase fit
+```
+The shaping-reviewer runs targeted reviews across the six quality dimensions.
+
+**Export to Linear**
+```
+Format our completed shaping artifacts as a Linear output package with milestones and starter issues
+```
+The shaping-formatter produces a structured package ready for import into Linear.
+
+**Write a specific artifact**
+```
+Write a problem frame for this initiative — define the trigger, impact, success criteria, appetite, and non-goals
+```
+Individual skills can be invoked directly without running the full pipeline.
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- writing-context-briefs
-- writing-problem-frames
-- writing-domain-scenarios
-- writing-ux-breadboards
-- writing-architecture-sketches
-- writing-risk-registers
-- writing-pitches
-- writing-milestones
-- reviewing-api-contracts
-- reviewing-data-models
-- reviewing-security
-- reviewing-test-strategy
-- reviewing-release-plans
-- reviewing-codebase-fit
-- formatting-linear-output
+
+| Skill | Purpose |
+|-------|---------|
+| `writing-context-briefs` | Raw inputs → structured facts, references, glossary, assumptions, unknowns |
+| `writing-problem-frames` | Trigger, impact, success criteria, appetite, non-goals, constraints |
+| `writing-domain-scenarios` | Personas, mental models, workflows, edge cases, domain vocabulary |
+| `writing-ux-breadboards` | User flows, screen states, error states, navigation maps, affordances |
+| `writing-architecture-sketches` | Solution boundary, components, data shapes, integration points, hard parts |
+| `writing-risk-registers` | Rabbit holes, external dependencies, unknowables, fallback plans |
+| `writing-pitches` | Synthesized persuasive pitch for the betting table |
+| `writing-milestones` | Phased delivery with exit criteria, sequencing rationale, scope-at-risk |
+| `reviewing-api-contracts` | Endpoint coverage, naming consistency, error responses, authorization |
+| `reviewing-data-models` | Normalization, referential integrity, naming conventions, migration safety |
+| `reviewing-security` | Threat model, authentication, authorization, PII handling, audit logging |
+| `reviewing-test-strategy` | Scenario coverage, test type distribution, edge cases, testability |
+| `reviewing-release-plans` | Rollout strategy, migration safety, observability, rollback procedures |
+| `reviewing-codebase-fit` | Architecture assumptions vs actual codebase — patterns, naming, complexity |
+| `formatting-linear-output` | Artifacts → Linear project with milestones, documents, and starter issues |
 
 ### Agents
-- shaping_analyst
-- shaping_designer
-- shaping_architect
-- shaping_strategist
-- shaping_reviewer
-- shaping_formatter
 
-### Tools
-- None
+| Agent | Role |
+|-------|------|
+| `shaping-analyst` | Produces Context Brief and Problem Frame from raw project input |
+| `shaping-designer` | Produces Domain Scenarios and UX Breadboards from the problem frame |
+| `shaping-architect` | Produces Architecture Sketch and Risk Register |
+| `shaping-strategist` | Synthesizes upstream artifacts into Pitch and Milestone Map |
+| `shaping-reviewer` | Validates artifacts across 6 quality dimensions |
+| `shaping-formatter` | Formats artifacts as structured Linear Output Package |
+
+</details>
+
+---
+
+**Domain:** project-shaping · **Technologies:** Harness-agnostic · **Aliases:** shaping, shape-up, project-shaping

--- a/repo-documentation-authoring/README.md
+++ b/repo-documentation-authoring/README.md
@@ -1,28 +1,81 @@
 # Repo Documentation Authoring
 
-Scaffolds, authors, and audits the essential repository documentation files recommended by GitHub for discoverability, community health, and contributor onboarding.
+Scaffold and maintain the community health files that GitHub recommends — README, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, issue templates, PR templates, CODEOWNERS, and more. This bundle audits what you have, scores documentation health across five dimensions, and generates what's missing.
 
-## Metadata
+## Quick Start
 
-- **Domain:** repo-documentation
-- **Risk Level:** low
-- **Technologies:** None (vendor-agnostic)
-- **Aliases:** repo-docs, readme-authoring, community-health
+Install via the [Mush CLI](https://github.com/musher-dev/mush):
 
-## Components
+```sh
+mush bundle install musher-dev/repo-documentation-authoring
+```
+
+Then invoke from any compatible harness (Claude Code, Codex, OpenCode, Copilot, Gemini CLI):
+
+```
+Audit our repo documentation and tell me what community health files are missing or incomplete
+```
+
+## What's Inside
+
+The bundle ships two agents and seven skills covering the full repository documentation lifecycle.
+
+The **repo_docs_auditor** agent runs a read-only assessment of your documentation health across five dimensions: Presence (do the files exist?), Completeness (are sections filled in?), Currency (are they up to date?), Discoverability (can contributors find them?), and Quality (do they meet standards?). It produces a severity-prioritized findings report with a remediation roadmap.
+
+The **repo_docs_author** agent orchestrates the full authoring workflow — scaffolding starter files, then writing each document with content adapted to your project type (library, CLI tool, web app, monorepo, etc.).
+
+Individual writing skills handle each document type: README with structured sections, CONTRIBUTING with dev setup and PR process, SECURITY with disclosure process and response SLAs, CODE_OF_CONDUCT based on Contributor Covenant 2.1, SUPPORT with channel routing, GOVERNANCE with decision-making models, FUNDING.yml for sponsorship, issue templates (bug report, feature request), PR templates, CODEOWNERS for automatic reviewer assignment, and CHANGELOG following Keep a Changelog 1.1.0.
+
+## Usage Examples
+
+**Audit documentation health**
+```
+Score our repository's documentation health — check presence, completeness, currency, and quality of all community health files
+```
+The repo_docs_auditor produces a 5-dimension score with prioritized remediation steps.
+
+**Scaffold all community health files**
+```
+Scaffold starter files for all the missing community health documents in this repo
+```
+Creates template files for every recommended document that doesn't exist yet.
+
+**Write a CONTRIBUTING guide**
+```
+Write a CONTRIBUTING.md for this project — include dev setup, branching workflow, coding standards, and PR process
+```
+Generates a guide tailored to your project's tech stack and workflow.
+
+**Write a security policy**
+```
+Write a SECURITY.md with responsible disclosure process, supported versions, response SLAs, and safe harbor provisions
+```
+Produces a security policy following industry best practices for vulnerability reporting.
+
+<details>
+<summary><strong>Components</strong></summary>
 
 ### Skills
-- `scaffolding-repo-documentation` — Scaffold starter files for all community health documents
-- `writing-readme` — Author README.md with structured sections adapted by project type
-- `writing-contributing-guide` — Author CONTRIBUTING.md with dev setup, workflow, and PR process
-- `writing-security-policy` — Author SECURITY.md with disclosure process and response SLAs
-- `writing-community-policies` — Author CODE_OF_CONDUCT, SUPPORT, GOVERNANCE, and FUNDING.yml
-- `writing-github-config` — Author issue templates, PR template, CODEOWNERS, and CHANGELOG
-- `auditing-repo-documentation` — Score documentation health across 5 dimensions with remediation roadmap
+
+| Skill | Purpose |
+|-------|---------|
+| `scaffolding-repo-documentation` | Scaffold starter files for all community health documents |
+| `writing-readme` | README.md with structured sections adapted by project type |
+| `writing-contributing-guide` | CONTRIBUTING.md — dev setup, workflow, coding standards, PR process |
+| `writing-security-policy` | SECURITY.md — disclosure process, response SLAs, severity classification, safe harbor |
+| `writing-community-policies` | CODE_OF_CONDUCT, SUPPORT, GOVERNANCE, FUNDING.yml |
+| `writing-github-config` | Issue templates, PR template, CODEOWNERS, CHANGELOG |
+| `auditing-repo-documentation` | 5-dimension documentation health scoring with remediation roadmap |
 
 ### Agents
-- `repo_docs_author` — Orchestrates the full documentation authoring workflow from scaffolding through writing
-- `repo_docs_auditor` — Read-only auditor that scores documentation health and produces prioritized findings
 
-### Tools
-- None
+| Agent | Role |
+|-------|------|
+| `repo_docs_author` | Orchestrates full authoring workflow from scaffolding through writing |
+| `repo_docs_auditor` | Read-only health scoring with severity-prioritized findings |
+
+</details>
+
+---
+
+**Domain:** repo-documentation · **Technologies:** Harness-agnostic · **Aliases:** repo-docs, readme-authoring, community-health


### PR DESCRIPTION
## Summary

- Restructure all 12 bundle READMEs from component inventory lists to user-facing hub documentation
- Each README now includes: value proposition, Quick Start with `mush bundle install`, narrative explaining how agents/skills collaborate, usage examples as natural-language prompts, collapsible component reference
- Fix incorrect/missing component listings in agent-asset-authoring, database-schema-governance, and project-shaping-orchestration
- Update root README bundle table with linked directory names and matching taglines

## Test plan

- [ ] Verify `<details>` blocks render correctly on GitHub
- [ ] Verify `<details>` blocks render correctly on hub.musher.dev
- [ ] Confirm all skills/agents in each bundle directory appear in their README component table
- [ ] Grep for Claude-specific language (none should exist — all READMEs are harness-agnostic)
- [ ] Check `mush bundle install` namespace is consistent across all READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)