### PR TITLE
feat: add demo-starter SDK example bundle

### DIFF
--- a/sdk-examples/README.md
+++ b/sdk-examples/README.md
@@ -11,6 +11,7 @@ These are **Musher registry bundles** (structured with `musher.yaml` and asset f
 | `agent-toolkit/` | `musher-examples/agent-toolkit` | 2.0.0 | Showcase all asset types for enumeration and inspection | Python: `pull_bundle`, `inspect_manifest` |
 | `code-review-kit/` | `musher-examples/code-review-kit` | 1.2.0 | Installable skills for Claude, OpenAI, and VS Code integration | TypeScript: `pull-bundle`, `resolve-bundle`, `install-project-skills`, `install-vscode-skills`; Python: `install_project_skills`, `export_plugin`, OpenAI examples |
 | `data-workflows/` | `musher-examples/data-workflows` | 1.0.0 | CSV data analysis and summarization in hosted containers | Python: OpenAI `hosted_inline_skill` |
+| `demo-starter/` | `musher-dev/demo-starter` | 1.0.0 | Demonstration bundle for SDK pull/install examples | Python: `pull_bundle`; TypeScript: `pull-bundle` |
 | `prompt-library/` | `musher-examples/prompt-library` | 1.2.0 | Typed resource access (prompts, toolsets, agent specs) | Python: `bundle_resources`, PydanticAI `instructions_from_bundle`, `dynamic_instructions` |
 
 ## Structure

--- a/sdk-examples/demo-starter/README.md
+++ b/sdk-examples/demo-starter/README.md
@@ -1,0 +1,25 @@
+# Demo Starter
+
+Demonstration bundle showcasing the Musher platform with practical skills and agents for everyday development workflows. Used as the primary bundle for the Python and TypeScript SDK examples in the [demo repo](https://github.com/musher-dev/demo).
+
+## Registry
+
+- **Name:** `musher-dev/demo-starter`
+- **Version:** 1.0.0
+- **Repository:** https://github.com/musher-dev/demo
+
+## Assets
+
+| Logical Path | Type | Description |
+|---|---|---|
+| `skills/summarizing-changes/SKILL.md` | skill | Summarize git history, staged diffs, or PR changes into clear summaries grouped by theme |
+| `skills/writing-commit-messages/SKILL.md` | skill | Generate Conventional Commits-compliant commit messages from staged changes |
+| `agent_specs/code-reviewer.json` | agent_spec | Review code for quality, correctness, security, and best-practice adherence |
+
+## Used By SDK Examples
+
+### Python SDK
+- `examples/` — `musher.pull("musher-dev/demo-starter:1.0.0")`
+
+### TypeScript SDK
+- `examples/` — `musher.pull("musher-dev/demo-starter:1.0.0")`

--- a/sdk-examples/demo-starter/agent_specs/code-reviewer.json
+++ b/sdk-examples/demo-starter/agent_specs/code-reviewer.json
@@ -1,0 +1,15 @@
+{
+  "name": "code-reviewer",
+  "description": "Review code for quality, correctness, security, and best-practice adherence.",
+  "model": "claude-sonnet-4-6",
+  "temperature": 0.2,
+  "skills": [
+    "summarizing-changes"
+  ],
+  "permissions": {
+    "file_read": true,
+    "file_write": false,
+    "terminal": false,
+    "web_search": false
+  }
+}

--- a/sdk-examples/demo-starter/musher.yaml
+++ b/sdk-examples/demo-starter/musher.yaml
@@ -1,0 +1,13 @@
+name: musher-dev/demo-starter
+version: 1.0.0
+description: >
+  A demonstration bundle showcasing the Musher platform with practical skills
+  and agents for everyday development workflows.
+
+assets:
+  - logical_path: skills/summarizing-changes/SKILL.md
+    asset_type: skill
+  - logical_path: skills/writing-commit-messages/SKILL.md
+    asset_type: skill
+  - logical_path: agent_specs/code-reviewer.json
+    asset_type: agent_spec

--- a/sdk-examples/demo-starter/skills/summarizing-changes/SKILL.md
+++ b/sdk-examples/demo-starter/skills/summarizing-changes/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: summarizing-changes
+description: >
+  Summarize git history, staged diffs, or PR changes into clear, human-readable
+  summaries grouped by theme.
+---
+
+# Summarizing Changes
+
+Produce concise, theme-grouped summaries from git history, staged diffs, or pull request changes.
+
+## Approach
+
+### 1. Identify the Change Source
+
+Determine what to summarize:
+
+- **Git history** — a range of commits (e.g., last 10 commits, since a tag, between branches)
+- **Staged diff** — changes currently staged for commit
+- **PR changes** — the full diff of a pull request
+
+Use `git log`, `git diff --staged`, or the PR diff depending on the source.
+
+### 2. Categorize Changes by Theme
+
+Group related changes into logical themes:
+
+- **Features** — new functionality or capabilities added
+- **Fixes** — bug fixes and error corrections
+- **Refactoring** — structural changes that don't alter behavior
+- **Documentation** — updates to docs, comments, or READMEs
+- **Infrastructure** — CI/CD, build config, dependency updates
+- **Tests** — new or updated test cases
+
+Assign each change to the most appropriate theme. A single commit may span multiple themes if it touches unrelated areas.
+
+### 3. Write the Summary
+
+For each theme with changes:
+
+- Lead with the theme name as a heading
+- List 2-5 bullet points describing the most significant changes
+- Use past tense, active voice ("Added pagination to the users endpoint")
+- Include file paths or function names when they add clarity
+- Omit trivial changes (whitespace, formatting) unless they are the only changes
+
+### 4. Add Context
+
+After the themed sections:
+
+- State the total number of commits, files changed, and lines added/removed
+- Note any breaking changes or migration requirements
+- Flag large diffs that may need closer review
+
+## Output Format
+
+```
+## Summary
+
+### {Theme}
+- {Change description}
+- {Change description}
+
+### {Theme}
+- {Change description}
+
+---
+{N} commits | {N} files changed | +{N} -{N} lines
+```
+
+## Guidelines
+
+- Keep each bullet to one sentence
+- Prioritize impact over volume — a one-line security fix matters more than a 500-line rename
+- When summarizing a large range, focus on the most meaningful changes and note how many minor changes were omitted
+- Do not editorialize — describe what changed, not whether it was a good idea

--- a/sdk-examples/demo-starter/skills/writing-commit-messages/SKILL.md
+++ b/sdk-examples/demo-starter/skills/writing-commit-messages/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: writing-commit-messages
+description: >
+  Generate Conventional Commits-compliant commit messages from staged changes
+  or a description of work done.
+---
+
+# Writing Commit Messages
+
+Generate structured commit messages that follow the Conventional Commits specification from staged changes or a description of the work.
+
+## Approach
+
+### 1. Analyze the Changes
+
+Examine the staged diff or provided description:
+
+- Identify which files were added, modified, or deleted
+- Determine the primary intent — is this a feature, fix, refactor, docs update, or chore?
+- Note the scope — which module, component, or area of the codebase is affected
+
+### 2. Select the Commit Type
+
+Choose the appropriate Conventional Commits type:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | A new feature or capability |
+| `fix` | A bug fix |
+| `docs` | Documentation-only changes |
+| `style` | Formatting, whitespace, semicolons (no logic change) |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Adding or updating tests |
+| `chore` | Build process, dependencies, tooling |
+| `perf` | Performance improvements |
+| `ci` | CI/CD configuration changes |
+
+### 3. Determine the Scope
+
+Identify a short scope token in parentheses:
+
+- Use the module, package, or component name (e.g., `auth`, `api`, `cli`)
+- Omit the scope if the change spans multiple unrelated areas
+- Keep it to one word when possible
+
+### 4. Write the Message
+
+Structure the commit message:
+
+- **Subject line**: `{type}({scope}): {description}` — imperative mood, lowercase, no period, max 72 characters
+- **Body** (optional): explain *why* the change was made, not *what* changed (the diff shows that)
+- **Footer** (optional): reference issues (`Closes #123`), note breaking changes (`BREAKING CHANGE: ...`)
+
+## Output Format
+
+```
+{type}({scope}): {short description}
+
+{Optional body explaining motivation and context}
+
+{Optional footer with references or breaking change notes}
+```
+
+## Examples
+
+Single-line:
+```
+feat(api): add pagination to the list users endpoint
+```
+
+With body and footer:
+```
+fix(auth): prevent token refresh race condition
+
+Two concurrent requests could both attempt to refresh an expired token,
+causing one to fail with a 401. Added a mutex to serialize refresh calls.
+
+Closes #42
+```
+
+## Guidelines
+
+- Use imperative mood in the subject ("add", not "added" or "adds")
+- Keep the subject line under 72 characters
+- Do not end the subject line with a period
+- Separate subject from body with a blank line
+- The body should explain *why*, not *what*
+- If the change is trivial (typo fix, formatting), a subject line alone is sufficient
+- Flag breaking changes in both the type (`feat!`) and the footer


### PR DESCRIPTION
## Summary
- Add `musher-dev/demo-starter:1.0.0` bundle to `sdk-examples/` so the Python and TypeScript SDK demo examples can resolve it from the registry
- Includes `summarizing-changes` skill, `writing-commit-messages` skill, and `code-reviewer` agent spec
- Updates `sdk-examples/README.md` bundles table with the new entry

Closes #7

## Test plan
- [ ] Verify `musher.yaml` parses correctly and asset logical paths match actual files
- [ ] Confirm SDK examples can pull `musher-dev/demo-starter:1.0.0` without `BundleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)